### PR TITLE
Fixed issue with empty actions in Jenkins crashing the app

### DIFF
--- a/app/services/Jenkins.js
+++ b/app/services/Jenkins.js
@@ -48,7 +48,7 @@ module.exports = function () {
             if(build.actions) {
                 for (var i = 0; i < build.actions.length; i++) {
                     var action = build.actions[i];
-                    if (action.causes) {
+                    if ((action) && (action.causes)) {
                         for (var j = 0; j < action.causes.length; j++) {
                             var cause = action.causes[j];
                             if(cause && cause.userName) {


### PR DESCRIPTION
Jenkins frequently returns empty action items as part of previous builds (I still haven't identified why), but these empty blocks cause node to crash with the following error:

    TypeError: Cannot read property 'causes' of null
    at getRequestedFor (/build-mon/app/services/Jenkins.js:51:31)
    at simplifyBuild (/build-mon/app/services/Jenkins.js:72:31)
    at /build-mon/app/services/Jenkins.js:14:33
    at Request._callback (/build-mon/node_modules/jenkins-api/lib/main.js:139:17)
    at Request.self.callback (/build-mon/node_modules/request/request.js:373:22)
    at Request.emit (events.js:98:17)
    at Request.<anonymous> (/build-mon/node_modules/request/request.js:1318:14)
    at Request.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (/build-mon/node_modules/request/request.js:1266:12)
    at IncomingMessage.emit (events.js:117:20)
    error: Forever detected script exited with code: 8



Sample actions block returned by Jenkins:

actions: [
{
causes: [
{
shortDescription: "Started by an SCM change"
}
]
},
{ },
{ },
{},
{ },
{ },
{ },
{ }
],