### PR TITLE
Update to jenkins-api 0.2.6 to add options on HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ Supports the [Jenkins](http://jenkins-ci.org/) build service.
   "name": "Jenkins",
   "configuration": {
     "url": "http://jenkins_username:jenkins_password@jenkins-server:8080",
-    "job": "JenkinsJobName"
+    "job": "JenkinsJobName",
+    "options": {
+      "strictSSL": false
+    }
   }
 }
 ```
@@ -104,6 +107,8 @@ Supports the [Jenkins](http://jenkins-ci.org/) build service.
 |--------------|----------------------------------------------------------------------------------------------------------------------------|
 | `url`        | The url to the Jenkins server. It has to be in the [following format](https://github.com/jansepar/node-jenkins-api#setup). |
 | `job`        | The name of the Jenkins Job                                                                                                |
+| `options`    | The request options.                                                                                                       |
+|              | Refer to [request module](https://github.com/request/request#requestdefaultsoptions) options for possible values           |
 
 #### TeamCity
 

--- a/app/services/Jenkins.js
+++ b/app/services/Jenkins.js
@@ -81,7 +81,7 @@ module.exports = function () {
     self.configure = function (config) {
         self.configuration = config;
 
-        jenkins = jenkinsapi.init(self.configuration.url);
+        jenkins = jenkinsapi.init(self.configuration.url, self.configuration.options || {});
     };
 
     self.check = function (callback) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "errorhandler": "1.3.0",
     "express": "4.10.6",
     "jade": "1.8.2",
-    "jenkins-api": "0.2.5",
+    "jenkins-api": "0.2.6",
     "moment": "2.8.4",
     "morgan": "1.5.0",
     "request": "2.51.0",


### PR DESCRIPTION
This PR allows users to configure the jenkins API calls using the new version of the jenkins-api module. For example, one can configure the jenkins service to switch off the strictSSL like this:

    {
      "name": "Jenkins",
      "configuration": {
        "url": "https://ci-openpaas.linagora.com/jenkins",
        "job": "openpaas-rse-oncommit",
        "options": {
          "strictSSL": false
        }
      }
    }

The options in jenkins-api follows the request module options.

Cheers,
Christophe