### PR TITLE
Fix GitLab issue where know projects were not updated once builds were enabled

### DIFF
--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -219,11 +219,20 @@ module.exports = function () {
                             });
                         } else {
                             log('Error', body);
+                            process.nextTick(function() {
+                                callback([]);
+                            });
+                            process.nextTick(function() {
+                                pass(null, []);
+                            });
                         }
                     });
                 });
             } else {
                 log('Error', body);
+                process.nextTick(function() {
+                    callback([]);
+                });
             }
         });
     }
@@ -363,6 +372,9 @@ module.exports = function () {
             async.filter(projects, function (project, include) {
                 if (typeof self.cache.projects[project.id] === 'undefined') {
                     include(true);
+                } else if (self.cache.projects[project.id]
+                                     .builds_enabled === false) {
+                   include(true);
                 } else {
                     include(false);
                 }


### PR DESCRIPTION
We've been running GitLab-integration 24/7 since the first implementation. I'll try to provide fixes when I remember. This fix issue where integration didn't update projects that were known to have builds disabled, but whose builds were turned on.

As a recap, we are running a monitor against GitLab with about 1k repositories and want it to automatically choose jobs with builds. Therefore all the optimization to not constantly poll all the repos. (And different monitors are customized simply by limiting GitLab token permissions and keeping node-build-monitor config simple.) 