### PR TITLE
App crashes when slugs key is missing in config.json for Gitlab Service

### DIFF
--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -474,7 +474,7 @@ module.exports = function () {
             self.config.intervals.default = minute;
         }
         if (typeof self.config.slugs === 'undefined') {
-            self.config.intervals.slugs = ['*/*'];
+            self.config.slugs = ['*/*'];
         }
         if (typeof process.env.GITLAB_TOKEN !== 'undefined') {
             self.config.token = process.env.GITLAB_TOKEN;


### PR DESCRIPTION
```
/Projects/node-build-monitor/app/services/GitLab.js:334
        if (self.config.slugs.indexOf('*/*') > -1 || self.config.slugs.indexOf(project.path_with_namespace) > -1) {
                             ^

TypeError: Cannot read property 'indexOf' of undefined
    at updateProject (/Projects/node-build-monitor/app/services/GitLab.js:334:30)
    at /Projects/node-build-monitor/app/services/GitLab.js:391:21
    at /Projects/node-build-monitor/node_modules/async/lib/async.js:356:13
    at iterate (/Projects/node-build-monitor/node_modules/async/lib/async.js:262:13)
    at async.forEachOfSeries.async.eachOfSeries (/Projects/node-build-monitor/node_modules/async/lib/async.js:281:9)
    at _asyncMap (/Projects/node-build-monitor/node_modules/async/lib/async.js:355:9)
    at Object.mapSeries (/Projects/node-build-monitor/node_modules/async/lib/async.js:347:20)
    at /Projects/node-build-monitor/app/services/GitLab.js:390:23
    at /Projects/node-build-monitor/node_modules/async/lib/async.js:414:13
    at /Projects/node-build-monitor/node_modules/async/lib/async.js:52:16
```