### PR TITLE
All Gitlab projects in a namespace specified with a single slug

### DIFF
--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -311,7 +311,7 @@ module.exports = function () {
 
     function updateProject(project, callback) {
         log('Updating project:', project.name_with_namespace);
-        if (self.config.slugs.indexOf('*/*') > -1 || self.config.slugs.indexOf(project.path_with_namespace) > -1) {
+        if (self.config.slugs.indexOf('*/*') > -1 || self.config.slugs.indexOf(project.namespace.name + "/*")  > -1 || self.config.slugs.indexOf(project.path_with_namespace) > -1) {
           if (typeof project.builds === 'undefined') {
               project.builds = {};
           }


### PR DESCRIPTION
We have multiple projects in a single group, and we add projects based on different components.  Instead of having to update the config file, pull it into our Docker container, and restart each time we add a new project, it would be easier to specify just the group name followed by /* to get all the projects in the group to automatically populate on the build monitor.  

I am just pulling the information out of the same JSON response, but looking for a match on the namespace name and /* in addition to looking for the exact name match or default (*/*).