### PR TITLE
Ability to pull multiple BuddyBuild apps instead of having to specify each one as a separate service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 *.sublime-workspace
 log.txt
+.idea/

--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ Supports [BuddyBuild](https://buddybuild.com/) build service
 
 | Setting          | Description
 |------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| `project_name`   | Label of the project name, normally IOS or Android.
-| `app_id`         | BuddyBuild Application ID
+| `project_name`   | Label of the project name, normally IOS or Android. Required only if you app_id is provided.
+| `app_id`         | BuddyBuild Application ID. Leave empty to get all the builds for your user token.
 | `url`            | BuddyBuild Build Query url
 | `access_token`   | Secret token string for the existing user to be used to authenticate against BuddyBuild REST API (if `BUILDBUDDY_ACCESS_TOKEN` environment variable is set, this setting is overwritten)
 | `build_id`       | Leave empty to get the latest build. Provide the build ID to query that specific build.

--- a/app/services/BuddyBuild.js
+++ b/app/services/BuddyBuild.js
@@ -1,139 +1,177 @@
 var request = require('request'),
-    async = require('async');
+  async = require('async');
 
 module.exports = function () {
-    var self = this,
-        getRequestHeaders = function () { // build request header
-            if (typeof process.env.BUILDBUDDY_ACCESS_TOKEN !== 'undefined') {
-                self.configuration.access_token = process.env.BUILDBUDDY_ACCESS_TOKEN;
-            }
-            return {
-                'ACCESS-TOKEN': self.configuration.access_token,
-                'Authorization': 'Bearer ' + self.configuration.access_token,
-                'accept-encoding': 'application/json'
-            };
+  var self = this,
+    getRequestHeaders = function () { // build request header
+      if (typeof process.env.BUILDBUDDY_ACCESS_TOKEN !== 'undefined') {
+        self.configuration.access_token = process.env.BUILDBUDDY_ACCESS_TOKEN;
+      }
+      return {
+        'ACCESS-TOKEN': self.configuration.access_token,
+        'Authorization': 'Bearer ' + self.configuration.access_token,
+        'accept-encoding': 'application/json'
+      };
+    },
+    makeUrl = function (app_id, build_id, branch, baseUrl) { //assemble url with designated branch id
+      if (build_id) { // to query one build provide a build_id
+        baseUrl += '/' + build_id;
+      } else if (app_id) { // to get lastest build provide app_id but no build_id
+        baseUrl += "/" + app_id + "/build/latest?branch=" + branch;
+      }
+
+      return baseUrl;
+    },
+    makeRequest = function (url, callback) { //make http request to BuildBuddy API
+      request({
+          headers: getRequestHeaders(),
+          url: url,
+          json: true
         },
-        makeUrl = function (app_id, build_id, branch, baseUrl) { //assemble url with designated branch id
-            if (build_id) { // to query one build provide a build_id
-                baseUrl += '/' + build_id;
-            } else if (app_id) { // to get lastest build provide app_id but no build_id
-                baseUrl += "/" + app_id + "/build/latest?branch=" + branch;
-            }
+        function (error, response, body) {
+          if (error) {
+            callback(error);
+            return;
+          }
 
-            return baseUrl;
-        },
-        makeRequest = function (url, callback) { //make http request to BuildBuddy API
-            request({
-                    headers: getRequestHeaders(),
-                    url: url,
-                    json: true
-                },
-                function (error, response, body) {
-                    if (error) {
-                      callback(error);
-                      return;
-                    }
+          if (response.statusCode === 500) {
+            callback(new Error(response.statusMessage));
+            return;
+          }
 
-                    if (response.statusCode === 500) {
-                      callback(new Error(response.statusMessage));
-                      return;
-                    }
+          callback(error, body);
+        });
+    },
+    parseDate = function (dateAsString) {
+      return new Date(dateAsString);
+    },
+    forEachResult = function (body, callback) {
 
-                    callback(error, body);
-                });
-        },
-        parseDate = function (dateAsString) {
-            return new Date(dateAsString);
-        },
-        forEachResult = function (body, callback) {
+      callback(body);
 
-            callback(body);
+    },
+    forEachApp = function (body, callback) {
+      for (var i = 0; i < body.length; i++) {
+        callback(body[i]);
+      }
 
-        },
-        isNullOrWhiteSpace = function (string) {
-            if (!string) {
-                return true;
-            }
+    },
+    isNullOrWhiteSpace = function (string) {
+      if (!string) {
+        return true;
+      }
 
-            return string === null || string.match(/^ *$/) !== null;
-        },
-        getStatus = function (statusText) {
-            switch (statusText) {
-                case "success":
-                    return "Green";
-                case "failed":
-                    return "Red";
-                case "running":
-                    return "Blue";
-                case "stopped":
-                    return "Red";
-                case "queued":
-                    return "Blue";
-                case "canceled":
-                    return "#FFA500";
-                default:
-                    return "Gray";
-            }
-        },
-        parseLink = function (appId, buildId) { // point to the build
-            return 'https://dashboard.buddybuild.com/apps/' + appId + '/build/' + buildId;
-        },
-        simplifyBuild = function (res) {
-            return {
-                id: res._id,
-                platform: self.configuration.project_name,
-                project: self.configuration.project_name + ': ' + res.commit_info.branch,
-                number: 'Build: ' + res.build_number,
-                isRunning: res.BuildFinished,
-                startedAt: parseDate(res.started_at),
-                finishedAt: parseDate(res.finished_at),
-                requestedFor: res.commit_info.author,
-                statusText: res.build_status,
-                status: getStatus(res.build_status),
-                reason: res.commit_info.message,
-                finished: res.finished,
-                hasErrors: !isNullOrWhiteSpace(res.Errors),
-                hasWarnings: !isNullOrWhiteSpace(res.Warnings),
-                branch: res.commit_info.branch,
-                url: parseLink(res.app_id, res._id)
-            };
-        },
-        queryBuilds = function (callback) { // query the build
-            makeRequest(makeUrl(self.configuration.app_id, self.configuration.build_id, self.configuration.branch, self.configuration.url), function (error, body) {
-                if (error) {
-                  callback(error);
-                  return;
-                }
+      return string === null || string.match(/^ *$/) !== null;
+    },
+    getStatus = function (statusText) {
+      switch (statusText) {
+        case "success":
+          return "Green";
+        case "failed":
+          return "Red";
+        case "running":
+          return "Blue";
+        case "stopped":
+          return "Red";
+        case "queued":
+          return "Blue";
+        case "canceled":
+          return "#FFA500";
+        default:
+          return "Gray";
+      }
+    },
+    parseLink = function (appId, buildId) { // point to the build
+      return 'https://dashboard.buddybuild.com/apps/' + appId + '/build/' + buildId;
+    },
+    simplifyBuild = function (app, res) {
+      return {
+        id: res._id,
+        platform: app ? app.platform : self.configuration.project_name,
+        project: app ? app.app_name : self.configuration.project_name + ': ' + res.commit_info.branch,
+        number: 'Build: ' + res.build_number,
+        isRunning: res.BuildFinished,
+        startedAt: parseDate(res.started_at),
+        finishedAt: parseDate(res.finished_at),
+        requestedFor: res.commit_info.author,
+        statusText: res.build_status,
+        status: getStatus(res.build_status),
+        reason: res.commit_info.message,
+        finished: res.finished,
+        hasErrors: !isNullOrWhiteSpace(res.Errors),
+        hasWarnings: !isNullOrWhiteSpace(res.Warnings),
+        branch: res.commit_info.branch,
+        url: parseLink(res.app_id, res._id)
+      };
+    },
+    queryBuilds = function (callback) { // query the build
+      makeRequest(makeUrl(self.configuration.app_id, self.configuration.build_id, self.configuration.branch, self.configuration.url), function (error, body) {
+        if (error) {
+          callback(error);
+          return;
+        }
 
-                var builds = [];
+        var builds = [];
 
-                forEachResult(body, function (res) {
-                    builds.push(simplifyBuild(res));
-                });
+        forEachResult(body, function (res) {
+          builds.push(simplifyBuild(null, res));
+        });
 
-                callback(error, builds);
-            });
-        };
+        callback(error, builds);
+      });
+    },
+    queryBuildsAsync = function (app) { // query the build
+      return new Promise(function (resolve, reject) {
+        makeRequest(makeUrl(app._id, null, self.configuration.branch, self.configuration.url), function (error, body) {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve(simplifyBuild(app, body));
+        });
+      })
+    },
+    queryAllAppBuilds = function (callback) { // query the build
+      makeRequest(makeUrl(null, null, self.configuration.branch, self.configuration.url), function (error, body) {
+        if (error) {
+          callback(error);
+          return;
+        }
+        var asyncBuildsQuery = body.map(function (app) {
+          return queryBuildsAsync(app)
+        });
 
-    self.configure = function (config) {
-        self.configuration = config;
+        Promise.all(asyncBuildsQuery).then(function (builds) {
+          callback(error, builds);
+        });
+      });
     };
 
-    self.check = function (callback) {
-        queryBuilds(callback);
-    };
+  self.configure = function (config) {
+    self.configuration = config;
+  };
 
-    self.makeURL = function (app_id, build_id, branch, url) {
-        return makeUrl(app_id, build_id, branch, url);
-    };
+  self.check = function (callback) {
+    if (self.configuration.app_id) {
+      console.log('Fetching builds for app : ' + self.configuration.app_id);
+      queryBuilds(callback);
+    } else {
+      console.log('app_id not specified, fetching builds for all apps ...');
+      queryAllAppBuilds(callback);
+    }
+  };
 
-    self.getHeaders = function (access_token) {
-        self.configuration.access_token = access_token;
-        return getRequestHeaders();
-    };
+  self.makeURL = function (app_id, build_id, branch, url) {
+    return makeUrl(app_id, build_id, branch, url);
+  };
 
-    self.getStatus = function (statusText) {
-        "use strict";
-        return getStatus(statusText);
-    };
+  self.getHeaders = function (access_token) {
+    self.configuration.access_token = access_token;
+    return getRequestHeaders();
+  };
+
+  self.getStatus = function (statusText) {
+    "use strict";
+    return getStatus(statusText);
+  };
 };

--- a/app/services/BuddyBuild.js
+++ b/app/services/BuddyBuild.js
@@ -1,177 +1,177 @@
 var request = require('request'),
-  async = require('async');
+    async = require('async');
 
 module.exports = function () {
-  var self = this,
-    getRequestHeaders = function () { // build request header
-      if (typeof process.env.BUILDBUDDY_ACCESS_TOKEN !== 'undefined') {
-        self.configuration.access_token = process.env.BUILDBUDDY_ACCESS_TOKEN;
-      }
-      return {
-        'ACCESS-TOKEN': self.configuration.access_token,
-        'Authorization': 'Bearer ' + self.configuration.access_token,
-        'accept-encoding': 'application/json'
-      };
-    },
-    makeUrl = function (app_id, build_id, branch, baseUrl) { //assemble url with designated branch id
-      if (build_id) { // to query one build provide a build_id
-        baseUrl += '/' + build_id;
-      } else if (app_id) { // to get lastest build provide app_id but no build_id
-        baseUrl += "/" + app_id + "/build/latest?branch=" + branch;
-      }
-
-      return baseUrl;
-    },
-    makeRequest = function (url, callback) { //make http request to BuildBuddy API
-      request({
-          headers: getRequestHeaders(),
-          url: url,
-          json: true
+    var self = this,
+        getRequestHeaders = function () { // build request header
+            if (typeof process.env.BUILDBUDDY_ACCESS_TOKEN !== 'undefined') {
+                self.configuration.access_token = process.env.BUILDBUDDY_ACCESS_TOKEN;
+            }
+            return {
+                'ACCESS-TOKEN': self.configuration.access_token,
+                'Authorization': 'Bearer ' + self.configuration.access_token,
+                'accept-encoding': 'application/json'
+            };
         },
-        function (error, response, body) {
-          if (error) {
-            callback(error);
-            return;
+        makeUrl = function (app_id, build_id, branch, baseUrl) { //assemble url with designated branch id
+            if (build_id) { // to query one build provide a build_id
+                baseUrl += '/' + build_id;
+            } else if (app_id) { // to get lastest build provide app_id but no build_id
+                baseUrl += "/" + app_id + "/build/latest?branch=" + branch;
+            }
+
+            return baseUrl;
+        },
+        makeRequest = function (url, callback) { //make http request to BuildBuddy API
+            request({
+                    headers: getRequestHeaders(),
+                    url: url,
+                    json: true
+                },
+                function (error, response, body) {
+                    if (error) {
+                      callback(error);
+                      return;
+                    }
+
+                    if (response.statusCode === 500) {
+                      callback(new Error(response.statusMessage));
+                      return;
+                    }
+
+                    callback(error, body);
+                });
+        },
+        parseDate = function (dateAsString) {
+            return new Date(dateAsString);
+        },
+        forEachResult = function (body, callback) {
+
+            callback(body);
+
+        },
+        forEachApp = function (body, callback) {
+          for (var i = 0; i < body.length; i++) {
+            callback(body[i]);
           }
 
-          if (response.statusCode === 500) {
-            callback(new Error(response.statusMessage));
-            return;
-          }
+        },
+        isNullOrWhiteSpace = function (string) {
+            if (!string) {
+                return true;
+            }
 
-          callback(error, body);
-        });
-    },
-    parseDate = function (dateAsString) {
-      return new Date(dateAsString);
-    },
-    forEachResult = function (body, callback) {
+            return string === null || string.match(/^ *$/) !== null;
+        },
+        getStatus = function (statusText) {
+            switch (statusText) {
+                case "success":
+                    return "Green";
+                case "failed":
+                    return "Red";
+                case "running":
+                    return "Blue";
+                case "stopped":
+                    return "Red";
+                case "queued":
+                    return "Blue";
+                case "canceled":
+                    return "#FFA500";
+                default:
+                    return "Gray";
+            }
+        },
+        parseLink = function (appId, buildId) { // point to the build
+            return 'https://dashboard.buddybuild.com/apps/' + appId + '/build/' + buildId;
+        },
+        simplifyBuild = function (app, res) {
+            return {
+                id: res._id,
+                platform: app ? app.platform : self.configuration.project_name,
+                project: app ? app.app_name : self.configuration.project_name + ': ' + res.commit_info.branch,
+                number: 'Build: ' + res.build_number,
+                isRunning: res.BuildFinished,
+                startedAt: parseDate(res.started_at),
+                finishedAt: parseDate(res.finished_at),
+                requestedFor: res.commit_info.author,
+                statusText: res.build_status,
+                status: getStatus(res.build_status),
+                reason: res.commit_info.message,
+                finished: res.finished,
+                hasErrors: !isNullOrWhiteSpace(res.Errors),
+                hasWarnings: !isNullOrWhiteSpace(res.Warnings),
+                branch: res.commit_info.branch,
+                url: parseLink(res.app_id, res._id)
+            };
+        },
+        queryBuilds = function (callback) { // query the build
+            makeRequest(makeUrl(self.configuration.app_id, self.configuration.build_id, self.configuration.branch, self.configuration.url), function (error, body) {
+                if (error) {
+                  callback(error);
+                  return;
+                }
 
-      callback(body);
+                var builds = [];
 
-    },
-    forEachApp = function (body, callback) {
-      for (var i = 0; i < body.length; i++) {
-        callback(body[i]);
-      }
+                forEachResult(body, function (res) {
+                    builds.push(simplifyBuild(null, res));
+                });
 
-    },
-    isNullOrWhiteSpace = function (string) {
-      if (!string) {
-        return true;
-      }
+                callback(error, builds);
+            });
+        },
+        queryBuildsAsync = function (app) { // query the build
+          return new Promise(function (resolve, reject) {
+            makeRequest(makeUrl(app._id, null, self.configuration.branch, self.configuration.url), function (error, body) {
+              if (error) {
+                reject(error);
+                return;
+              }
+              resolve(simplifyBuild(app, body));
+            });
+          })
+        },
+        queryAllAppBuilds = function (callback) { // query the build
+          makeRequest(makeUrl(null, null, self.configuration.branch, self.configuration.url), function (error, body) {
+            if (error) {
+              callback(error);
+              return;
+            }
+            var asyncBuildsQuery = body.map(function (app) {
+              return queryBuildsAsync(app)
+            });
 
-      return string === null || string.match(/^ *$/) !== null;
-    },
-    getStatus = function (statusText) {
-      switch (statusText) {
-        case "success":
-          return "Green";
-        case "failed":
-          return "Red";
-        case "running":
-          return "Blue";
-        case "stopped":
-          return "Red";
-        case "queued":
-          return "Blue";
-        case "canceled":
-          return "#FFA500";
-        default:
-          return "Gray";
-      }
-    },
-    parseLink = function (appId, buildId) { // point to the build
-      return 'https://dashboard.buddybuild.com/apps/' + appId + '/build/' + buildId;
-    },
-    simplifyBuild = function (app, res) {
-      return {
-        id: res._id,
-        platform: app ? app.platform : self.configuration.project_name,
-        project: app ? app.app_name : self.configuration.project_name + ': ' + res.commit_info.branch,
-        number: 'Build: ' + res.build_number,
-        isRunning: res.BuildFinished,
-        startedAt: parseDate(res.started_at),
-        finishedAt: parseDate(res.finished_at),
-        requestedFor: res.commit_info.author,
-        statusText: res.build_status,
-        status: getStatus(res.build_status),
-        reason: res.commit_info.message,
-        finished: res.finished,
-        hasErrors: !isNullOrWhiteSpace(res.Errors),
-        hasWarnings: !isNullOrWhiteSpace(res.Warnings),
-        branch: res.commit_info.branch,
-        url: parseLink(res.app_id, res._id)
-      };
-    },
-    queryBuilds = function (callback) { // query the build
-      makeRequest(makeUrl(self.configuration.app_id, self.configuration.build_id, self.configuration.branch, self.configuration.url), function (error, body) {
-        if (error) {
-          callback(error);
-          return;
-        }
+            Promise.all(asyncBuildsQuery).then(function (builds) {
+              callback(error, builds);
+            });
+          });
+        };
 
-        var builds = [];
-
-        forEachResult(body, function (res) {
-          builds.push(simplifyBuild(null, res));
-        });
-
-        callback(error, builds);
-      });
-    },
-    queryBuildsAsync = function (app) { // query the build
-      return new Promise(function (resolve, reject) {
-        makeRequest(makeUrl(app._id, null, self.configuration.branch, self.configuration.url), function (error, body) {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve(simplifyBuild(app, body));
-        });
-      })
-    },
-    queryAllAppBuilds = function (callback) { // query the build
-      makeRequest(makeUrl(null, null, self.configuration.branch, self.configuration.url), function (error, body) {
-        if (error) {
-          callback(error);
-          return;
-        }
-        var asyncBuildsQuery = body.map(function (app) {
-          return queryBuildsAsync(app)
-        });
-
-        Promise.all(asyncBuildsQuery).then(function (builds) {
-          callback(error, builds);
-        });
-      });
+    self.configure = function (config) {
+        self.configuration = config;
     };
 
-  self.configure = function (config) {
-    self.configuration = config;
-  };
+    self.check = function (callback) {
+        if (self.configuration.app_id) {
+          console.log('Fetching builds for app : ' + self.configuration.app_id);
+          queryBuilds(callback);
+        } else {
+          console.log('app_id not specified, fetching builds for all apps ...');
+          queryAllAppBuilds(callback);
+        }
+    };
 
-  self.check = function (callback) {
-    if (self.configuration.app_id) {
-      console.log('Fetching builds for app : ' + self.configuration.app_id);
-      queryBuilds(callback);
-    } else {
-      console.log('app_id not specified, fetching builds for all apps ...');
-      queryAllAppBuilds(callback);
-    }
-  };
+    self.makeURL = function (app_id, build_id, branch, url) {
+        return makeUrl(app_id, build_id, branch, url);
+    };
 
-  self.makeURL = function (app_id, build_id, branch, url) {
-    return makeUrl(app_id, build_id, branch, url);
-  };
+    self.getHeaders = function (access_token) {
+        self.configuration.access_token = access_token;
+        return getRequestHeaders();
+    };
 
-  self.getHeaders = function (access_token) {
-    self.configuration.access_token = access_token;
-    return getRequestHeaders();
-  };
-
-  self.getStatus = function (statusText) {
-    "use strict";
-    return getStatus(statusText);
-  };
+    self.getStatus = function (statusText) {
+        "use strict";
+        return getStatus(statusText);
+    };
 };

--- a/app/services/BuddyBuild.js
+++ b/app/services/BuddyBuild.js
@@ -129,7 +129,7 @@ module.exports = function () {
               }
               resolve(simplifyBuild(app, body));
             });
-          })
+          });
         },
         queryAllAppBuilds = function (callback) { // query the build
           makeRequest(makeUrl(null, null, self.configuration.branch, self.configuration.url), function (error, body) {
@@ -138,7 +138,7 @@ module.exports = function () {
               return;
             }
             var asyncBuildsQuery = body.map(function (app) {
-              return queryBuildsAsync(app)
+              return queryBuildsAsync(app);
             });
 
             Promise.all(asyncBuildsQuery).then(function (builds) {

--- a/test/services/BuddyBuild.js
+++ b/test/services/BuddyBuild.js
@@ -49,14 +49,20 @@ describe('BuddyBuild service', function () {
 
     describe('makeUrl', function () {
         it('should return valid url to the latest build of the specified branch', function () {
-            var url = "https://buildbuddy.com/APPID/build/latest?branch=develop";
-            var sampleParam = BB.makeURL('APPID', '', 'develop', "https://buildbuddy.com");
+            var url = "https://buddybuild.com/APPID/build/latest?branch=develop";
+            var sampleParam = BB.makeURL('APPID', '', 'develop', "https://buddybuild.com");
             assert(url === sampleParam, "Expecting Format: " + url + " Received: " + sampleParam);
         });
 
         it('should return valid url to specified build', function () {
-            var url = "https://buildbuddy.com/BUILDID";
-            var sampleParam = BB.makeURL('', 'BUILDID', '', "https://buildbuddy.com");
+            var url = "https://buddybuild.com/BUILDID";
+            var sampleParam = BB.makeURL('', 'BUILDID', '', "https://buddybuild.com");
+            assert(url === sampleParam, "Expecting Format: " + url + " Received: " + sampleParam);
+        });
+
+        it('should return valid url to all given token when app_is is not given', function () {
+            var url = "https://api.buddybuild.com/v1/apps";
+            var sampleParam = BB.makeURL('', '', '', "https://api.buddybuild.com/v1/apps");
             assert(url === sampleParam, "Expecting Format: " + url + " Received: " + sampleParam);
         });
     });


### PR DESCRIPTION
If a user token has multiple buddy build apps (ios / andriod for different envs like dev / staging / prod etc as in my case), today you'll have to specify each app as a different service. However, thats we can simplify that by first fetching all the builds and then iterate over them to get latest build for each.

Kindly accept the MR if you think it makes sense