### PR TITLE
Get rid of "finished 47 years ago" for Builds that have not started yet

### DIFF
--- a/app/public/scripts/BuildViewModel.js
+++ b/app/public/scripts/BuildViewModel.js
@@ -46,15 +46,31 @@ define(['ko', 'moment', 'countdown'], function (ko, moment, countdown) {
         }, this);
 
         this.time = ko.forcibleComputed(function () {
-            return this.isRunning() ?
-                'started ' + moment(this.startedAt()).fromNow() :
-                'finished ' + moment(this.finishedAt()).fromNow();
+            if (this.isRunning()) {
+                return 'started ' + moment(this.startedAt()).fromNow();
+            }
+
+            var beginningOfTime = new Date(0).toISOString();
+
+            if (this.startedAt().toISOString() === beginningOfTime) {
+                return '';
+            }
+
+            return 'finished ' + moment(this.finishedAt()).fromNow();
         }, this);
 
         this.duration = ko.forcibleComputed(function () {
-            return this.isRunning() ?
-                'running for ' + countdown(this.startedAt()).toString() :
-                'ran for ' + countdown(this.startedAt(), this.finishedAt()).toString();
+            if (this.isRunning()) {
+                return 'running for ' + countdown(this.startedAt()).toString();
+            }
+
+            var beginningOfTime = new Date(0).toISOString();
+
+            if (this.finishedAt().toISOString() === beginningOfTime) {
+                return '';
+            }
+
+            return 'ran for ' + countdown(this.startedAt(), this.finishedAt()).toString();
         }, this);
 
         this.isMenuAvailable = ko.computed(function () {

--- a/app/public/templates/themes/default.html
+++ b/app/public/templates/themes/default.html
@@ -18,7 +18,9 @@
         <div class="medium-height nowrap prio-vertical-one">
           <span data-bind="text: statusText" class="middle status"></span>
           <span class="middle duration-block reset-height prio-horizontal-three">
+            <!-- ko if: time -->
             <span class="duration-icon fa fa-clock-o"></span>
+            <!-- /ko -->
             <span data-bind="text: time" class="middle time"></span>
             <br />
             <span data-bind="text: duration" class="middle time"></span>

--- a/app/public/templates/themes/lingo.html
+++ b/app/public/templates/themes/lingo.html
@@ -19,10 +19,11 @@
       <span> by </span>
       <span class="emphasize" data-bind="text: requestedFor"></span><span>, </span>
 
+      <!-- ko if: time -->
       <span data-bind="text: time"></span>
       <span> and </span>
       <span data-bind="text: duration"></span>
-
+      <!-- /ko -->
       <span> with the status </span>
       <span class="emphasize" data-bind="text: statusText"></span><span>.</span>
 

--- a/app/public/templates/themes/list.html
+++ b/app/public/templates/themes/list.html
@@ -22,11 +22,13 @@
         <span data-bind="text: requestedFor"></span>
       </div>
       <div class="part-3">
+        <!-- ko if: time -->
         <span class="fa fa-clock-o"></span>
         <span> </span>
         <span data-bind="text: time"></span>
         <span> and </span>
         <span data-bind="text: duration"></span>
+        <!-- /ko -->
         <span data-bind="visible: hasWarnings() || hasErrors()">
           <span> | </span>
           <span data-bind="visible: hasWarnings" class="fa fa-exclamation-triangle"></span>

--- a/app/public/templates/themes/lowres.html
+++ b/app/public/templates/themes/lowres.html
@@ -22,7 +22,9 @@
           </span>
           
           <span class="middle duration-block reset-height prio-horizontal-three">
+            <!-- ko if: time -->
             <span class="duration-icon fa fa-clock-o"></span>
+            <!-- /ko -->
             <span data-bind="text: time" class="middle time"></span>
             <br />
             <span data-bind="text: duration" class="middle time"></span>


### PR DESCRIPTION
Currently, a build only has an `isRunning` flag. If this flag is set to false, it is assumed that the build has finished, though it might not have started yet. In this case, the Build Monitor displays the following: 
`finished 47 years ago 
ran for`

This PR alters the `time` and `duration` computation in `BuildViewModel.js` to reflect that a build could not have started yet. Also, it adds a check to the template, to only display the clock icon if it is needed.