### PR TITLE
Update Gitlab.js to use API V4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.sublime-workspace
 log.txt
 .idea/
+/package-lock.json

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Supports an on-premise [GitLab](http://gitlab.com) Community Edition/Enterprise 
   "configuration": {
     "url": "http://gitlab.example.com:8080",
     "token": "secret_user_token",
+    "additional_query": "&search=gitlab-org&starred=true",
     "slugs": [
       "gitlab-org/gitlab-ci-multi-runner"
     ],
@@ -255,16 +256,20 @@ Supports an on-premise [GitLab](http://gitlab.com) Community Edition/Enterprise 
 }
 ```
 
-| Setting       | Description
-|---------------|-------------------------------------------------------------------------------------------------------------
-| `url`         | GitLab server http(s) address string
-| `token`       | Secret token string for the existing user to be used to authenticate against GitLab REST API
-| `slugs`       | List of project slugs to display and check for builds. Defaults to `*/*` for all projects you have access to
-| `intervals`   | How often (in integer of milliseconds) ...
-| `.disabled`   | ... to poll all GitLab projects, including projects with builds disabled, for new builds
-| `.empty`      | ... to poll GitLab projects with builds enabled, but still without any builds yet, for new builds
-| `.default`    | ... to poll GitLab projects with existing builds
-| `debug`       | Boolean to run GitLab plugin in verbose mode
+| Setting            | Description
+|--------------------|-------------------------------------------------------------------------------------------------------------
+| `url`              | GitLab server http(s) address string
+| `token`            | Secret token string for the existing user to be used to authenticate against GitLab REST API
+| `slugs`            | List of project slugs to display and check for builds. Defaults to `*/*` for all projects you have access to
+| `intervals`        | How often (in integer of milliseconds) ...
+| `additional_query` | Add [additional query parameters](https://gitlab.com/help/api/projects.md) so not too many projects are fetched. 
+| `.disabled`        | ... to poll all GitLab projects, including projects with builds disabled, for new builds
+| `.empty`           | ... to poll GitLab projects with builds enabled, but still without any builds yet, for new builds
+| `.default`         | ... to poll GitLab projects with existing builds
+| `debug`            | Boolean to run GitLab plugin in verbose mode
+
+Because API V4 returns **all** internal and public projects by default, you propably
+want to set `additional_query` as well. Good choices could be `&owned=true` or `&membership=true`.  
 
 #### BuddyBuild
 


### PR DESCRIPTION
* Versions of Gitlab > 9 provide a new API V4, the old API V3 will be
  deprecated with one the next 9.x versions.
* Besides of renamed member fields (builds are now called jobs), the new
  API will retrieve a lot more projects.
* Therefore a new config field `additional_query` is introduced which
  may be used to filter the jobs list beforehand.