### PR TITLE
Fixed issues in gitlab

### DIFF
--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -69,7 +69,7 @@ module.exports = function () {
     }
 
     function getBuildId (project, job) {
-        return project.id + '-' + job.ref + '-' + job.stage;
+        return project.id + '-' + job.pipeline.id;
     }
 
     //noinspection JSUnusedLocalSymbols
@@ -262,20 +262,8 @@ module.exports = function () {
                 if (typeof seen[key] === 'undefined') {
                     seen[key] = build;
                     return true;
-                }
-                else if (seen[key].monitor.startedAt < build.monitor.startedAt) {
-                    seen[key] = build;
-                    return true;
                 } else {
                     return false;
-                }
-            })
-            .filter(build => {
-                if (!latest || build.monitor.startedAt > latest) {
-                    latest = build.monitor.startedAt;
-                    return true;
-                } else {
-                    return build.monitor.isRunning || build.status === 'failing';
                 }
             });
 

--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -38,7 +38,7 @@ module.exports = function () {
     }
 
     function getBuildExpiration(job) {
-        if (job.status !== 'running') {
+        if (job.pipeline.status !== 'running') {
             return getDefaultExpiration();
         } else {
             return now();
@@ -84,8 +84,8 @@ module.exports = function () {
 
     //noinspection JSUnusedLocalSymbols
     function getBuildIsRunning (project, job) {
-        return (job.status === 'running' ||
-                job.status === 'pending');
+        return (job.pipeline.status === 'running' ||
+                job.pipeline.status === 'pending');
     }
 
     //noinspection JSUnusedLocalSymbols
@@ -105,7 +105,7 @@ module.exports = function () {
 
     //noinspection JSUnusedLocalSymbols
     function getBuildStatus (project, job) {
-        switch (job.status) {
+        switch (job.pipeline.status) {
             case 'pending':
                 return '#ffa500';
             case 'running':
@@ -121,7 +121,7 @@ module.exports = function () {
 
     //noinspection JSUnusedLocalSymbols
     function getBuildStatusText (project, job) {
-        return job.stage + ' ' + job.status;
+        return job.pipeline.status;
     }
 
     //noinspection JSUnusedLocalSymbols


### PR DESCRIPTION
1. Builds are reduced based on timestamp instead of pipeline.
2. Return pipeline status instead of job status.

Build monitor should show the status of the pipeline and not the job. Job level status must be a secondary level of information.