### PR TITLE
Fixing broken TeamCity service

### DIFF
--- a/app/monitor.js
+++ b/app/monitor.js
@@ -25,21 +25,24 @@ var async = require('async'),
             });
         }
         else {
-            var takeDate = function (build) {
+            sortBuildsByDate(newBuilds);
+        }
+    },
+    sortBuildsByDate = function(newBuilds){
+        var takeDate = function (build) {
                 return build.isRunning ? build.startedAt : build.finishedAt;
             };
 
-            newBuilds.sort(function (a, b) {
-                var dateA = takeDate(a);
-                var dateB = takeDate(b);
+        newBuilds.sort(function (a, b) {
+            var dateA = takeDate(a);
+            var dateB = takeDate(b);
 
-                if(dateA < dateB) return 1;
-                if(dateA > dateB) return -1;
+            if(dateA < dateB) return 1;
+            if(dateA > dateB) return -1;
 
-                return 0;
-            });
-        }
-    },
+            return 0;
+        });
+    }
     distinctBuildsByETag = function (newBuilds) {
         var unique = {};
 
@@ -154,6 +157,7 @@ module.exports = function () {
                 }
                 if(pluginBuilds.length > 0) {
                     if(self.configuration.latestBuildOnly) {
+                        sortBuildsByDate(pluginBuilds);
                         Array.prototype.push.apply(allBuilds, [pluginBuilds.shift()]);
                     } else {
                         Array.prototype.push.apply(allBuilds, pluginBuilds);

--- a/app/monitor.js
+++ b/app/monitor.js
@@ -42,7 +42,7 @@ var async = require('async'),
 
             return 0;
         });
-    }
+    },
     distinctBuildsByETag = function (newBuilds) {
         var unique = {};
 

--- a/app/requests.js
+++ b/app/requests.js
@@ -3,7 +3,7 @@ var request = require('request'),
 
 module.exports = {
   makeRequest: function (opts, callback) {
-    if (opts.authentication.trim() === 'ntlm') {
+    if (opts.authentication && opts.authentication.trim() === 'ntlm') {
       ntlm.get({
         url: opts.url,
         username: opts.username,
@@ -17,8 +17,7 @@ module.exports = {
           url: opts.url,
           rejectUnauthorized: false,
           headers: opts.headers || {},
-          json: true,
-          auth: {'user': opts.username, 'pass': opts.password}
+          json: true
         },
         function (error, response, body) {
           callback(error, body);

--- a/app/services/TeamCity.js
+++ b/app/services/TeamCity.js
@@ -39,7 +39,7 @@ module.exports = function () {
         makeRequest = function (url, callback) {
           request.makeRequest({
             authentication: self.configuration.authentication,
-            url: self.configuration.tfsProxyUrl || tryGetTfsProxyUrlOfDocker(),
+            url: url,
             username: self.configuration.username,
             password: self.configuration.password,
             headers: {Accept: 'application/json'}

--- a/app/services/TeamCity.js
+++ b/app/services/TeamCity.js
@@ -65,7 +65,7 @@ module.exports = function () {
             });
         },
         requestLastCommitDetails = function(build, callback) {
-            if(build.lastChanges.change && build.lastChanges.change[0]) {
+            if(build.lastChanges && build.lastChanges.change && build.lastChanges.change[0]) {
                 makeRequest(getHrefUrl(build.lastChanges.change[0].href), function(error, data) {
                     if (error) {
                         callback(error);


### PR DESCRIPTION
Bugs fixed : 
- NTLM work made it a requirement to add auth to teamcity service configuration which doesn't need to be mandatory.
- Refactor of getRequest led to the incorrect url being passed in the teamcity makeRequest call.
- Refactor of getRequest added auth to the "default" getRequest. Have removed it as doesn't work.
- Occasional issues of trying to get the latest commit caused the app to blow up. There is now protection against this.
- Previously the "LatestBuildOnly" would just grab the top build with no guarantee it is the latest build. Now we sort before shifting.