### PR TITLE
defensive programming: don't freak out if a job has no associated commit

### DIFF
--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -94,11 +94,11 @@ module.exports = function () {
         },
         getCommitMessage = function(build) {
             var job = build.jobs && build.jobs[0];
-            return job && job.commit.message;
+            return job && job.commit ? job.commit.message : undefined;
         },
         getAuthor = function(build) {
             var job = build.jobs && build.jobs[0];
-            return job && job.commit.author_name;
+            return job && job.commit ? job.commit.author_name : undefined;
         },
         getBuildStatus = function(status) {
             switch (status) {


### PR DESCRIPTION
This will fix https://github.com/marcells/node-build-monitor/issues/65