### PR TITLE
added numberOfPipelinesPerProject option to GitLab service config

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Supports an on-premise [GitLab](http://gitlab.com) Community Edition/Enterprise 
     "url": "http://gitlab.example.com:8080",
     "token": "secret_user_token",
     "additional_query": "&search=gitlab-org&starred=true",
+    "numberOfPipelinesPerProject": 3,
     "slugs": [
       {
         "project": "gitlab-org/gitlab-ci-multi-runner",
@@ -271,6 +272,7 @@ Supports an on-premise [GitLab](http://gitlab.com) Community Edition/Enterprise 
 | `slugs`            | List of project slugs to display and check for builds. Defaults to `*/*` for all projects you have access to. Optional 'ref' attribute can be used to specify the branch.
 | `intervals`        | How often (in integer of milliseconds) ...
 | `additional_query` | Add [additional query parameters](https://gitlab.com/help/api/projects.md) so not too many projects are fetched. 
+| `numberOfPipelinesPerProject` | Limit the number of pipelines fetched for each project. Optional, defaults to no limitation.
 
 Because API V4 returns **all** internal and public projects by default, you propably
 want to set `additional_query` as well. Good choices could be `&owned=true` or `&membership=true`.  

--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -42,6 +42,9 @@ module.exports = function () {
                     callback(err);
                     return;
                 }
+                if (typeof self.config.numberOfPipelinesPerProject !== 'undefined') {
+                    pipelines = pipelines.slice(0, self.config.numberOfPipelinesPerProject);
+                }
                 async.map(pipelines, function(pipeline, callback) {
                     getPipelineDetails(project, pipeline.id, callback);
                 }, callback);


### PR DESCRIPTION
This pull request adds a new configuration option called `numberOfPipelinesPerProject` to the GitLab service config, allowing the user to specify the maximum number of pipelines (builds) to fetch for a single project.

This will allow users to select a group of repositories (e.g., all repositories that are owned by the user corresponding to the key that the GitLab API is called with) and specify that the build monitor should show only X builds per project. When the builds are sorted by IDs (which is the case right now), this ensures that only the most recent X builds appear on the CI display. In our case, we use it with X=1 to show only the most recent build for a group of repositories being monitored.