### PR TITLE
Jenkins: added single-view mode that shows all jobs from a Jenkins view

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ Supports the [Travis CI](https://travis-ci.org/) build service.
 
 #### Jenkins
 
-Supports the [Jenkins](http://jenkins-ci.org/) build service.
+Supports the [Jenkins](http://jenkins-ci.org/) build service. The service can
+operate in single-job or single-view mode. In single-job mode, the builds of
+a selected Jenkins job are shown. In single-view mode, the builds of all the
+jobs in a given Jenkins view are shown. In both modes, one can limit the
+maximum number of recent builds per job.
 
 ```json
 {
@@ -116,6 +120,7 @@ Supports the [Jenkins](http://jenkins-ci.org/) build service.
     "username": "jenkins_username",
     "password": "jenkins_password",
     "job": "JenkinsJobName",
+    "numberOfBuildsPerJob": 3,
     "options": {
       "strictSSL": false
     }
@@ -128,9 +133,11 @@ Supports the [Jenkins](http://jenkins-ci.org/) build service.
 | `url`        | The url to the Jenkins server
 | `username`   | Your Jenkins user name
 | `password`   | Your Jenkins password
-| `job`        | The name of the Jenkins Job
+| `job`        | The name of the Jenkins job whose builds are to be shown in single-job mode. Takes precedence over `view` if both are given.
+| `view`       | The name of the Jenkins view whose jobs and builds are to be shown in single-view mode. Optional.
 | `options`    | The request options.
 |              | Refer to [request module](https://github.com/request/request#requestdefaultsoptions) options for possible values
+| `numberOfBuildsPerJob` | Limit the number of builds fetched for each job. Optional, defaults to no limitation.
 
 #### TeamCity
 


### PR DESCRIPTION
This pull request adds a single-view mode to the Jenkins service.

Currently the Jenkins service is capable of displaying all the builds from a single Jenkins job only. The pull request allows the user to specify the name of a single Jenkins *view* instead, and the service will fetch the builds of all the jobs that are part of the given Jenkins view instead. This way an organization can simply collect the jobs that should be shown on the build monitor into a single view, configure the build monitor to show this view only, and then add new projects to the build monitor later simply by updating the Jenkins view. (There is also no need to repeat the Jenkins credentials once for every job in the build monitor config).