### PR TITLE
GitLab service can now provide branch and commit information to the BuildViewModel

### DIFF
--- a/app/public/scripts/BuildViewModel.js
+++ b/app/public/scripts/BuildViewModel.js
@@ -5,6 +5,8 @@ define(['ko', 'moment', 'countdown'], function (ko, moment, countdown) {
         this.id = ko.observable();
         this.isRunning = ko.observable();
         this.project = ko.observable();
+        this.branch = ko.observable();
+        this.commit = ko.observable();
         this.definition = ko.observable();
         this.number = ko.observable();
         this.startedAt = ko.observable();
@@ -21,6 +23,8 @@ define(['ko', 'moment', 'countdown'], function (ko, moment, countdown) {
             this.id(build.id);
             this.isRunning(build.isRunning);
             this.project(build.project);
+            this.branch(build.branch);
+            this.commit(build.commit);
             this.definition(build.definition);
             this.number(build.number);
             this.startedAt(moment(build.startedAt));
@@ -59,6 +63,11 @@ define(['ko', 'moment', 'countdown'], function (ko, moment, countdown) {
 
         this.isMenuAvailable = ko.computed(function () {
             return this.url() || false;
+        }, this);
+
+        this.shortCommit = ko.computed(function () {
+            var commit = this.commit();
+            return commit !== undefined ? commit.substr(0, 7) : undefined;
         }, this);
     };
 

--- a/app/public/scripts/BuildViewModel.js
+++ b/app/public/scripts/BuildViewModel.js
@@ -64,11 +64,6 @@ define(['ko', 'moment', 'countdown'], function (ko, moment, countdown) {
         this.isMenuAvailable = ko.computed(function () {
             return this.url() || false;
         }, this);
-
-        this.shortCommit = ko.computed(function () {
-            var commit = this.commit();
-            return commit !== undefined ? commit.substr(0, 7) : undefined;
-        }, this);
     };
 
     return BuildViewModel;

--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -80,6 +80,8 @@ module.exports = function () {
                 id: project.id + '|' + build.id,
                 number: build.id,
                 project: project.name + '/' + build.ref,
+                branch: build.ref,
+                commit: build.sha,
                 isRunning: ['running', 'pending'].includes(build.status),
                 startedAt: getDateTime(build.started_at),
                 finishedAt: getDateTime(build.finished_at),

--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -81,7 +81,7 @@ module.exports = function () {
                 number: build.id,
                 project: project.name + '/' + build.ref,
                 branch: build.ref,
-                commit: build.sha,
+                commit: build.sha ? build.sha.substr(0, 7) : undefined,
                 isRunning: ['running', 'pending'].includes(build.status),
                 startedAt: getDateTime(build.started_at),
                 finishedAt: getDateTime(build.finished_at),


### PR DESCRIPTION
As discussed in #26: this PR adds support for forwarding branch and commit-related information from the GitLab service to the BuildViewModel. Other build services could be updated in a similar manner where such a change makes sense.

The themes are not updated yet so branches and commit hashes are not shown on the displays yet - one has to develop a custom theme for that.