### PR TITLE
GitLab: getBuilds() did not call its callback when the projects were not loaded yet -- now it does

### DIFF
--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -65,8 +65,14 @@ module.exports = function () {
         },
         getBuilds = function(callback) {
             if(self.projects.length === 0) {
-                loadProjects();
+                loadProjects(function () {
+                    _getBuilds(callback);
+                });
+            } else {
+                _getBuilds(callback);
             }
+        },
+        _getBuilds = function(callback) {
             async.map(self.projects, getProjectPipelines, function(err, builds) {
                 if(err) {
                     callback(err);
@@ -144,7 +150,7 @@ module.exports = function () {
                 }
             });
         },
-        loadProjects = function() {
+        loadProjects = function(callback) {
             var slugs = self.config.slugs,
                 matchers = slugs.map(slug => slug.project);
             getAllProjects(function(err, projects){
@@ -164,6 +170,7 @@ module.exports = function () {
                         self.projects.push(project);
                     }
                 });
+                callback();
             });
         };
 


### PR DESCRIPTION
There was a bug in the `getBuilds()` function of the GitLab service, which resulted in the callback not being called at all when the list of projects was not loaded from GitLab yet. This typically happened at startup. As a result, one had to wait until the next check _after_ the loading of the project list has completed before the builds appeared on the screen.

This PR fixes the bug by ensuring that `getBuilds()` calls its callback in both cases, i.e. when `self.projects.length === 0` and when `self.projects.length !== 0`.