### PR TITLE
Compare namespace path with project path

### DIFF
--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -159,7 +159,7 @@ module.exports = function () {
                 if(err) return;
                 var indexOfAllMatch = matchers.indexOf('*/*');
                 projects.forEach(function(project){
-                    var indexOfNamespace = matchers.indexOf(project.namespace.name + "/*"),
+                    var indexOfNamespace = matchers.indexOf(project.namespace.path + "/*"),
                         indexOfProject = matchers.indexOf(project.path_with_namespace),
                         index = indexOfAllMatch > -1 ? indexOfAllMatch : (
                             indexOfNamespace > -1 ? indexOfNamespace : (


### PR DESCRIPTION
At the moment the project name is used to compare with the namespace path. If the name contains whitespaces, the path does not match against the name.
The fix uses the path property.