### PR TITLE
Double asterisk support in gitlab slugs - include nested projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Supports an on-premise [GitLab](http://gitlab.com) Community Edition/Enterprise 
 |--------------------|-------------------------------------------------------------------------------------------------------------
 | `url`              | GitLab server http(s) address string
 | `token`            | Secret token string for the existing user to be used to authenticate against GitLab REST API
-| `slugs`            | List of project slugs to display and check for builds. Defaults to `*/*` for all projects you have access to. Optional 'ref' attribute can be used to specify the branch.
+| `slugs`            | List of project slugs to display and check for builds. Defaults to `*/*` for all projects you have access to. Use `/*` when specifying group slug to include projects only from current group and `/**` to also include subgroups. Optional 'ref' attribute can be used to specify the branch.
 | `intervals`        | How often (in integer of milliseconds) ...
 | `additional_query` | Add [additional query parameters](https://gitlab.com/help/api/projects.md) so not too many projects are fetched.
 | `numberOfPipelinesPerProject` | Limit the number of pipelines fetched for each project. Optional, defaults to no limitation.

--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -156,12 +156,25 @@ module.exports = function () {
         },
         loadProjects = function(callback) {
             var slugs = self.config.slugs,
-                matchers = slugs.map(slug => slug.project);
+                matchers = slugs.map(slug => slug.project),
+                findNamespaceIndexInMatchers = function(namespace) {
+                    for(var i = 0; i < matchers.length; i++){
+                        var matcher = matchers[i];
+                        if(matcher.endsWith("/**")){
+                            prefix = matcher.replace("/**","");
+                            if(namespace.full_path.startsWith(prefix)) return i;
+                        }else{
+                            if( matcher === namespace.full_path + "/*") return i;
+                        }
+                    }
+                    return -1;
+                };
+
             getAllProjects(function(err, projects){
                 if(err) return;
                 var indexOfAllMatch = matchers.indexOf('*/*');
                 projects.forEach(function(project){
-                    var indexOfNamespace = matchers.indexOf(project.namespace.path + "/*"),
+                    var indexOfNamespace = findNamespaceIndexInMatchers(project.namespace),
                         indexOfProject = matchers.indexOf(project.path_with_namespace),
                         index = indexOfAllMatch > -1 ? indexOfAllMatch : (
                             indexOfNamespace > -1 ? indexOfNamespace : (


### PR DESCRIPTION
Implemented double asterisk in gitlab slugs for subgroups wildcard support as discussed in  #93 