### PR TITLE
GitLab: config.numberOfPipelinesPerProject is optional

### DIFF
--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -42,8 +42,10 @@ module.exports = function () {
                     callback(err);
                     return;
                 }
-                if (pipelines && pipelines.slice && typeof self.config.numberOfPipelinesPerProject !== 'undefined') {
-                    pipelines = pipelines.slice(0, self.config.numberOfPipelinesPerProject);
+                if(pipelines && pipelines.slice) {
+                    if(typeof self.config.numberOfPipelinesPerProject !== 'undefined') {
+                        pipelines = pipelines.slice(0, self.config.numberOfPipelinesPerProject);
+                    }
                 } else {
                     pipelines = [];
                 }


### PR DESCRIPTION
Due to the recent merge of #91, the GitLab config parameter 'numberOfPipelinesPerProject' is no longer optional. With this pull request, the parameter will be optional again.