### PR TITLE
Use relative path for socket.io

### DIFF
--- a/app/public/scripts/main.js
+++ b/app/public/scripts/main.js
@@ -1,6 +1,6 @@
 require.config({
     paths: {
-        io: '/socket.io/socket.io',
+        io: 'socket.io/socket.io',
         ko: 'libs/knockout-3.2.0',
         moment: 'libs/moment.min',
         countdown: 'libs/countdown.min',


### PR DESCRIPTION
When running node-build-monitoring behind a proxy with a subfolder rewrite, the absolute path is a problem.