### PR TITLE
Fix relative path for socket.io

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -29,20 +29,20 @@ function getConfig() {
 
 function printStartupInformation() {
     const importantEnvironmentVariables = [
-        { 
+        {
             name : 'PORT',
-            defaultValue : '3000' 
+            defaultValue : '3000'
         },
         {
             name : 'NODE_TLS_REJECT_UNAUTHORIZED',
-            defaultValue : '1' 
+            defaultValue : '1'
         }];
 
     console.log(`Printing environment Variables...`);
     importantEnvironmentVariables
         .map(x => ({ variable : x, stringValue : process.env.hasOwnProperty(x.name) ? process.env[x.name] : `unset (Default: ${x.defaultValue})` }))
         .forEach(x => console.log(`    ${x.variable.name} = ${x.stringValue}`));
-  
+
     console.log('node-build-monitor is starting...');
 }
 

--- a/app/public/scripts/AppViewModel.js
+++ b/app/public/scripts/AppViewModel.js
@@ -6,7 +6,7 @@ define(['ko', 'notification', 'BuildViewModel', 'OptionsViewModel'], function (k
 
         this.isIntercepted = ko.observable();
         this.infoType = ko.observable();
-        this.faviconImageUrl = ko.observable('/images/favicon-unread.png');
+        this.faviconImageUrl = ko.observable('images/favicon-unread.png');
         this.builds = ko.observableArray([]);
         this.version = ko.observable();
         this.options = new OptionsViewModel(self);
@@ -28,9 +28,9 @@ define(['ko', 'notification', 'BuildViewModel', 'OptionsViewModel'], function (k
 
         this.setHasUnreadBuilds = function (value) {
             if (value) {
-              self.faviconImageUrl('/images/favicon-unread.png');
+              self.faviconImageUrl('images/favicon-unread.png');
             } else {
-              self.faviconImageUrl('/images/favicon.png');
+              self.faviconImageUrl('images/favicon.png');
             }
         };
 

--- a/app/public/scripts/BuildMonitorServer.js
+++ b/app/public/scripts/BuildMonitorServer.js
@@ -4,7 +4,7 @@ define(['io'], function (io) {
             cachedSettings;
 
         this.connect = function () {
-            pathname = document.location.pathname
+            pathname = document.location.pathname;
             separator = (pathname.substr(-1) == '/')?'':'/';
             io = io(undefined, {path: pathname + separator + 'socket.io/'});
             var socket = io.connect();

--- a/app/public/scripts/BuildMonitorServer.js
+++ b/app/public/scripts/BuildMonitorServer.js
@@ -4,6 +4,9 @@ define(['io'], function (io) {
             cachedSettings;
 
         this.connect = function () {
+            pathname = document.location.pathname
+            separator = (pathname.substr(-1) == '/')?'':'/';
+            io = io(undefined, {path: pathname + separator + 'socket.io/'});
             var socket = io.connect();
 
             socket.on('connect', self.onConnected);

--- a/app/public/scripts/knockoutExtensions.js
+++ b/app/public/scripts/knockoutExtensions.js
@@ -89,8 +89,8 @@ define(['ko'], function (ko) {
         var namingConventionLoader = {
             getConfig: function(name, callback) {
                 var templateConfig = {
-                    templateUrl: '/templates/themes/' + name + '.html',
-                    cssUrl: '/stylesheets/themes/' + name + '/style.css'
+                    templateUrl: 'templates/themes/' + name + '.html',
+                    cssUrl: 'stylesheets/themes/' + name + '/style.css'
                 };
 
                 callback({ template: templateConfig });

--- a/app/public/scripts/main.js
+++ b/app/public/scripts/main.js
@@ -1,6 +1,6 @@
 require.config({
     paths: {
-        io: '/socket.io/socket.io',
+        io: '../socket.io/socket.io',
         ko: 'libs/knockout-3.2.0',
         moment: 'libs/moment.min',
         countdown: 'libs/countdown.min',

--- a/app/public/stylesheets/base/style.css
+++ b/app/public/stylesheets/base/style.css
@@ -17,7 +17,7 @@ body {
 }
 
 .carbon-background {
-  background-image: url(/images/pattern-b8gl.png);
+  background-image: url(../../images/pattern-b8gl.png);
   background-repeat: repeat;
 }
 

--- a/app/views/index.pug
+++ b/app/views/index.pug
@@ -1,9 +1,9 @@
 extends layout.pug
 
 block scripts
-    script(src='/scripts/libs/jquery-2.1.0.min.js')
-    script(src='/scripts/libs/jquery.color-2.1.2.min.js')
-    script(data-main="/scripts/main", src='/scripts/libs/require-2.1.15.min.js')
+    script(src='scripts/libs/jquery-2.1.0.min.js')
+    script(src='scripts/libs/jquery.color-2.1.2.min.js')
+    script(data-main="scripts/main", src='scripts/libs/require-2.1.15.min.js')
 
 block content
     .full-size(data-bind='component: { name: options.theme(), params: { builds: builds } }, changeFavicon: faviconImageUrl')

--- a/app/views/layout.pug
+++ b/app/views/layout.pug
@@ -6,8 +6,8 @@ html
         meta(name='viewport', content='width=device-width, height=device-height, initial-scale=0.3')
 
         title= title
-        link(rel='stylesheet', href='/stylesheets/base/style.css')
-        link#basic-favicon(href='/images/favicon.png', rel='icon')
+        link(rel='stylesheet', href='stylesheets/base/style.css')
+        link#basic-favicon(href='images/favicon.png', rel='icon')
 
         block scripts
 


### PR DESCRIPTION
This PR adds support for running node-build-monitor in proxies in a subfolder, for example localhost/foobar/.

It fixes asset loading (JS, CSS and images) as well as socket.io path.

It can be tested with the following `docker-compose.yml` file:

```
version: '3'

services:
  node-build-monitor:
    build: .
    ports:
      - "3000:3000"
    labels:
      - "traefik.frontend.rule=PathPrefixStrip:/foobar/"

  proxy:
    image: traefik
    command: -c /dev/null --web --docker --docker.exposedbydefault=true
    ports:
      - "80:80"
      - "8080:8080"
    volumes:
    - /var/run/docker.sock:/var/run/docker.sock
```

Then you can verify that things work on http://localhost:3000 and http://localhost/foobar/