### PR TITLE
Sometimes TFS doesn't respond with the 'requestedFor' value.

### DIFF
--- a/app/services/Tfs.js
+++ b/app/services/Tfs.js
@@ -199,7 +199,7 @@ function VSTSRestBuilds() {
         number: build.buildNumber,
         project: build.definition.name,
         reason: build.reason,
-        requestedFor: build.requestedFor.displayName,
+        requestedFor: build.requestedFor ? build.requestedFor.displayName : '',
         startedAt: new Date(build.startTime),
         status: colorScheme[resultFilter[build.result ? build.result : resultFilter.inProgress]],
         statusText: build.result ? build.result : resultFilter.inProgress,


### PR DESCRIPTION
Sometimes TFS doesn't respond with the 'requestedFor' value. (Mostly scheduled/automatic builds) Don't prevent the entire build from displaying if thats the only part we are missing.