### PR TITLE
add in progress and stopped states to bamboo service

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,17 +362,19 @@ Supports [Bamboo](https://www.atlassian.com/software/bamboo) build service
     "url": "http://yourbamboo.com",
     "planKey": "Plan-Key",
     "username": "user",
-    "password": "pass"
+    "password": "pass",
+    "includeAllStates": true
   }
 }
 ```
 
-| Setting          | Description
-|------------------|------------------------------------
-| `url`            | URL of the Bamboo host
-| `planKey`        | Plan-Key
-| `username`       | HTTP-Basic-Auth Username (optional)
-| `password`       | HTTP-Basic-Auth Password (optional)
+| Setting            | Description
+|--------------------|------------------------------------
+| `url`              | URL of the Bamboo host
+| `planKey`          | Plan-Key
+| `username`         | HTTP-Basic-Auth Username (optional)
+| `password`         | HTTP-Basic-Auth Password (optional)
+| `includeAllStates` | include in-progress/stopped state (optional)
 
 #### Bitbucket Pipelines
 

--- a/app/services/Bamboo.js
+++ b/app/services/Bamboo.js
@@ -16,11 +16,21 @@ module.exports = function () {
             });
         });
     },
+    getUrlParams = function() {
+      var params = {
+        "os_authType": "basic"
+      };
+
+      if(self.configuration.includeAllStates &&
+        self.configuration.includeAllStates.toString().toLowerCase() === "true") {
+          params.includeAllStates = "1";
+      }
+
+      return params;
+    },
     requestBuilds = function (callback) {
         var planUri = self.configuration.url + "/rest/api/latest/result/" + self.configuration.planKey + ".json";
-        var urlParams = {
-            "os_authType": "basic"
-        };
+        var urlParams = getUrlParams();
 
         request({ uri: planUri, qs: urlParams }, function(error, response, body) {
             try {
@@ -33,9 +43,8 @@ module.exports = function () {
     },
     requestBuild = function (build, callback) {
         var planUri = self.configuration.url + "/rest/api/latest/result/" + self.configuration.planKey + "/" + build.number + ".json";
-        var urlParams = {
-            "os_authType": "basic"
-        };
+        var urlParams = getUrlParams();
+
         request({ uri: planUri, qs: urlParams }, function(error, response, body) {
             if (error) {
                 callback(error);
@@ -54,12 +63,12 @@ module.exports = function () {
             id: self.configuration.slug + '|' + res.number,
             project: res.plan.shortName,
             number: res.number,
-            isRunning: res.state === 'started',
+            isRunning: !res.buildCompletedTime,
             startedAt: res.buildStartedTime,
             finishedAt: res.buildCompletedTime,
             requestedFor: getAuthors(res.buildReason),
-            status: getStatus(res.state),
-            statusText: res.state,
+            status: getStatus(res.state, res.lifeCycleState),
+            statusText: getStatusText(res.state, res.lifeCycleState),
             reason: striptags(res.buildReason),
             hasErrors: !res.successful,
             hasWarnings: !res.successful,
@@ -78,12 +87,24 @@ module.exports = function () {
         }
         return 'System';
     },
-    getStatus = function(state) {
+    getStatus = function(state, lifeCycleState) {
         if (state === 'started') return "Blue";
         if (state === 'created') return "Blue";
         if (state === 'canceled') return "Gray";
         if (state === 'Failed') return "Red";
+        if (state === 'Unknown') {
+          if (lifeCycleState === 'NotBuilt') return 'Gray';
+          if (lifeCycleState === 'InProgress') return 'Yellow';
+        }
         return "Green";
+    },
+    getStatusText = function(state, lifeCycleState) {
+      if (state === 'Unknown') {
+        if (lifeCycleState === 'NotBuilt') return 'Stopped';
+        if (lifeCycleState === 'InProgress') return 'In Progress';
+      }
+
+      return state;
     };
 
     self.cache = {


### PR DESCRIPTION
Hi,

Please help to review my PR to add 2 additional states to Bamboo monitoring. Previously Bamboo is checking res.state which only returns either Successful or Failed. To check for additional states, I need to look into lifeCycleState

I also update isRunning to reverse of whether the buildCompletedTime is available. This is so that when sorting by date, in-progress/stopped state will be sorted according to start time

Many thanks
Best regards,