### PR TITLE
change in-progress background color for bamboo service

### DIFF
--- a/app/monitor.js
+++ b/app/monitor.js
@@ -37,10 +37,17 @@ var async = require('async'),
             var dateA = takeDate(a);
             var dateB = takeDate(b);
 
-            if(dateA < dateB) return 1;
-            if(dateA > dateB) return -1;
+            if (dateA && dateB) {
+              if(dateA < dateB) return 1;
+              if(dateA > dateB) return -1;
 
-            return 0;
+              return 0;
+            }
+            else {
+              // if either of the date is not available, compare by id
+              // build with higher id is sorted before build with lower id
+              return b.id.toString().localeCompare(a.id.toString());
+            }
         });
     },
     distinctBuildsByETag = function (newBuilds) {

--- a/app/services/Bamboo.js
+++ b/app/services/Bamboo.js
@@ -94,7 +94,7 @@ module.exports = function () {
         if (state === 'Failed') return "Red";
         if (state === 'Unknown') {
           if (lifeCycleState === 'NotBuilt') return 'Gray';
-          if (lifeCycleState === 'InProgress') return 'Yellow';
+          if (lifeCycleState === 'InProgress') return '#FF8C00';  // dark orange
         }
         return "Green";
     },


### PR DESCRIPTION
Hi,

Could you help to review a minor change in bamboo in-progress background color?

Before this change, in-progress status has yellow background and white text color which makes the text very difficult to see

<img width="364" alt="before" src="https://user-images.githubusercontent.com/5293047/40877574-c59b219a-66b5-11e8-8c3e-d914da0ee38a.png">

I change the color to dark orange so that it looks ok even with white text color

<img width="278" alt="after" src="https://user-images.githubusercontent.com/5293047/40877578-d6e9cfa0-66b5-11e8-938a-5ce7d15bea9c.png">

This is just a quick workaround. In my opinion, a proper fix should be decoupling status of the build with text/background colors. E.g. define a common set of status that all services can return (in-progress, success, fail...) and in BuildViewModel, determine the proper color depending on the status. Optionally each service can return different background/text color to override the default colors. However this change can be quite major and affect all the services, so not sure what's the best way to do this

====

I just pushed another commit to fix an issue with sorting of the builds by date when the build date is not available (.e.g. in Bamboo, when the build is stopped, both build start time and end time are not available). Before this commit, the sorting function compares date with null/undefined, resulting in incorrect result (stopped build is always the latest)

Thanks
Best regards,