### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ RUN npm install -g forever
 
 WORKDIR /build-mon
 
-ADD app /build-mon/app
 ADD package.json /build-mon/package.json
-ADD README.md /build-mon/README.md
-
 RUN npm install
 
-ONBUILD ADD config.json /build-mon/app/config.json
+ADD app /build-mon/app
+ADD README.md /build-mon/README.md
+
+ONBUILD ADD app/config.json /build-mon/app/config.json
 
 EXPOSE 3000
 


### PR DESCRIPTION
Due to how Docker's caching works, `npm install` was run every time something in `app` was changed.

This now runs `npm install` only when `package.json` changes, which makes subsequent Docker builds significantly faster.

I also changed it to use `app/config.json` directly, since I thought it was redundant to have an extra copy of the config file in the root of the repo.