### PR TITLE
 update Bamboo service to request only 1 build if latestBuildOnly is set to true

### DIFF
--- a/app/services/Bamboo.js
+++ b/app/services/Bamboo.js
@@ -1,104 +1,118 @@
 var request = require('request'),
-    async = require('async'),
-    striptags = require('striptags');
+  async = require('async'),
+  striptags = require('striptags');
 
 module.exports = function () {
-    var self = this,
-    queryBuilds = function (callback) {
-        requestBuilds(function (error, body) {
-            if (error) {
-                callback(error);
-                return;
-            }
-
-            async.map(body, requestBuild, function (error, results) {
-                callback(error, results);
-            });
-        });
+  var self = this,
+    logDebug = function (text) {
+      if (self.configuration.debug === true) {
+        console.log(new Date().toLocaleTimeString(), '|', text);
+      }
     },
-    getUrlParams = function() {
+    queryBuilds = function (callback) {
+      requestBuilds(function (error, body) {
+        if (error) {
+          callback(error);
+          return;
+        }
+
+        async.map(body, requestBuild, function (error, results) {
+          callback(error, results);
+        });
+      });
+    },
+    getUrlParams = function () {
       var params = {
         "os_authType": "basic"
       };
 
-      if(self.configuration.includeAllStates &&
+      if (self.configuration.includeAllStates &&
         self.configuration.includeAllStates.toString().toLowerCase() === "true") {
-          params.includeAllStates = "1";
+        params.includeAllStates = "1";
+      }
+
+      if (self.configuration.latestBuildOnly === true) {
+        params["max-results"] = "1";
       }
 
       return params;
     },
     requestBuilds = function (callback) {
-        var planUri = self.configuration.url + "/rest/api/latest/result/" + self.configuration.planKey + ".json";
-        var urlParams = getUrlParams();
+      var planPath = "/rest/api/latest/result/" + self.configuration.planKey + ".json";
+      var planUri = self.configuration.url + planPath;
+      logDebug("=== requesting " + planPath);
 
-        request({ uri: planUri, qs: urlParams }, function(error, response, body) {
-            try {
-                var bodyJson = JSON.parse(body);
-                callback(error, bodyJson.results.result);
-            } catch (parseError) {
-                callback(parseError, null);
-            }
-        });
+      var urlParams = getUrlParams();
+
+      request({ uri: planUri, qs: urlParams }, function (error, response, body) {
+        try {
+          var bodyJson = JSON.parse(body);
+          callback(error, bodyJson.results.result);
+        } catch (parseError) {
+          callback(parseError, null);
+        }
+      });
     },
     requestBuild = function (build, callback) {
-        var planUri = self.configuration.url + "/rest/api/latest/result/" + self.configuration.planKey + "/" + build.number + ".json";
-        var urlParams = getUrlParams();
+      var planPath = "/rest/api/latest/result/" + self.configuration.planKey + "/" + build.number + ".json";
+      var planUri = self.configuration.url + planPath;
+      logDebug("=== requesting " + planPath);
+      var urlParams = getUrlParams();
 
-        request({ uri: planUri, qs: urlParams }, function(error, response, body) {
-            if (error) {
-                callback(error);
-                return;
-            }
-            try {
-                var bodyJson = JSON.parse(body);
-                callback(error, simplifyBuild(bodyJson));
-            } catch (parseError) {
-                callback(parseError, null);
-            }
-        });
+      request({ uri: planUri, qs: urlParams }, function (error, response, body) {
+        if (error) {
+          callback(error);
+          return;
+        }
+        try {
+          var bodyJson = JSON.parse(body);
+          callback(error, simplifyBuild(bodyJson));
+        } catch (parseError) {
+          callback(parseError, null);
+        }
+      });
     },
     simplifyBuild = function (res) {
-        return {
-            id: self.configuration.slug + '|' + res.number,
-            project: res.plan.shortName,
-            number: res.number,
-            isRunning: !res.buildCompletedTime,
-            startedAt: res.buildStartedTime,
-            finishedAt: res.buildCompletedTime,
-            requestedFor: getAuthors(res.buildReason),
-            status: getStatus(res.state, res.lifeCycleState),
-            statusText: getStatusText(res.state, res.lifeCycleState),
-            reason: striptags(res.buildReason),
-            hasErrors: !res.successful,
-            hasWarnings: !res.successful,
-            url: self.configuration.url + '/browse/' + res.buildResultKey
-        };
+      return {
+        id: self.configuration.slug + '|' + res.number,
+        project: res.plan.shortName,
+        number: res.number,
+        isRunning: !res.buildCompletedTime,
+        startedAt: res.buildStartedTime,
+        finishedAt: res.buildCompletedTime,
+        requestedFor: getAuthors(res.buildReason),
+        status: getStatus(res.state, res.lifeCycleState),
+        statusText: getStatusText(res.state, res.lifeCycleState),
+        reason: striptags(res.buildReason),
+        hasErrors: !res.successful,
+        hasWarnings: !res.successful,
+        url: self.configuration.url + '/browse/' + res.buildResultKey
+      };
     },
-    getAuthors = function(reason) {
-        var urlRegex = /<a[^>]*>([\s\S]*?)<\/a>/g;
-        var links = reason.match(urlRegex);
-        if (links !== null) {
-            return links.map(
-                function(url) {
-                    return striptags(url);
-                }
-            ).join(', ');
-        }
-        return 'System';
+    getAuthors = function (reason) {
+      var urlRegex = /<a[^>]*>([\s\S]*?)<\/a>/g;
+      var links = reason.match(urlRegex);
+      if (links !== null) {
+        return links.map(
+          function (url) {
+            return striptags(url);
+          }
+        ).join(', ');
+      }
+      return 'System';
     },
-    getStatus = function(state, lifeCycleState) {
-        if (state === 'started') return "Blue";
-        if (state === 'created') return "Blue";
-        if (state === 'canceled') return "Gray";
-        if (state === 'Failed') return "Red";
-        if (state === 'Unknown') {
-          if (lifeCycleState === 'NotBuilt') return 'Gray';
-          if (lifeCycleState === 'InProgress') return '#FF8C00';  // dark orange
-        }
-        return "Green";
+    getStatus = function (state, lifeCycleState) {
+      if (state === 'started') return "Blue";
+      if (state === 'created') return "Blue";
+      if (state === 'canceled') return "Gray";
+      if (state === 'Failed') return "Red";
+      if (state === 'Unknown') {
+        if (lifeCycleState === 'NotBuilt') return 'Gray';
+        if (lifeCycleState === 'InProgress') return '#FF8C00';  // dark orange
+      }
+      return "Green";
     },
-    getStatusText = function(state, lifeCycleState) {
+    getStatusText = function (state, lifeCycleState) {
       if (state === 'Unknown') {
         if (lifeCycleState === 'NotBuilt') return 'Stopped';
         if (lifeCycleState === 'InProgress') return 'In Progress';
@@ -107,26 +121,26 @@ module.exports = function () {
       return state;
     };
 
-    self.cache = {
-        expires: 0,
-        projects: {}
-    };
+  self.cache = {
+    expires: 0,
+    projects: {}
+  };
 
-    self.configure = function (config) {
-        self.configuration = config;
+  self.configure = function (config) {
+    self.configuration = config;
 
-        if (config.username && config.password) {
-            var protocol = config.url.match(/(^|\s)(https?:\/\/)/i);
-            if (Array.isArray(protocol)) {
-                protocol = protocol[0];
-                var url = config.url.substr(protocol.length);
-                host = protocol + config.username + ":" + config.password + "@" + url;
-            }
-        }
-        self.configuration.url = host || config.url;
-    };
+    if (config.username && config.password) {
+      var protocol = config.url.match(/(^|\s)(https?:\/\/)/i);
+      if (Array.isArray(protocol)) {
+        protocol = protocol[0];
+        var url = config.url.substr(protocol.length);
+        host = protocol + config.username + ":" + config.password + "@" + url;
+      }
+    }
+    self.configuration.url = host || config.url;
+  };
 
-    self.check = function (callback) {
-        queryBuilds(callback);
-    };
+  self.check = function (callback) {
+    queryBuilds(callback);
+  };
 };

--- a/app/services/Bamboo.js
+++ b/app/services/Bamboo.js
@@ -5,7 +5,7 @@ var request = require('request'),
 module.exports = function () {
   var self = this,
     logDebug = function (text) {
-      if (self.configuration.debug === true) {
+      if (self.monitorConfiguration.debug === true) {
         console.log(new Date().toLocaleTimeString(), '|', text);
       }
     },
@@ -31,7 +31,7 @@ module.exports = function () {
         params.includeAllStates = "1";
       }
 
-      if (self.configuration.latestBuildOnly === true) {
+      if (self.monitorConfiguration.latestBuildOnly === true) {
         params["max-results"] = "1";
       }
 
@@ -126,8 +126,9 @@ module.exports = function () {
     projects: {}
   };
 
-  self.configure = function (config) {
+  self.configure = function (config, monitorConfig) {
     self.configuration = config;
+    self.monitorConfiguration = monitorConfig;
 
     if (config.username && config.password) {
       var protocol = config.url.match(/(^|\s)(https?:\/\/)/i);


### PR DESCRIPTION
Hi,

Could you help me to review this PR?

Previously Bamboo service didn't take into consideration latestBuildOnly parameter and therefore will made a lot of unnecessary requests even if latestBuildOnly is set to true. 

An example in our project is that we have 8 Bamboo build plan, it made 10-20 requests per build plan to fetch each build details although in the end it only used the latest build detail. This actually cause a problem in our Bamboo server, causing it to run out of db connections and lagging a lot

My PR modifies the app.js to pass in monitor configuration in addition to service configuration so that Bamboo service can check for latestBuildOnly and debug flags. If latestBuildOnly is set to true, it limits the request to bamboo server to return only 1 result. It also does some debugging logs if debug flag is set to true

Many thanks