### PR TITLE
add latestBuildPerBuildPlanOnly to Bamboo service

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,18 +365,20 @@ Supports [Bamboo](https://www.atlassian.com/software/bamboo) build service
     "planKey": "Plan-Key",
     "username": "user",
     "password": "pass",
-    "includeAllStates": true
+    "includeAllStates": true,
+    "latestBuildPerBuildPlanOnly": true
   }
 }
 ```
 
-| Setting            | Description
-|--------------------|------------------------------------
-| `url`              | URL of the Bamboo host
-| `planKey`          | Plan-Key
-| `username`         | HTTP-Basic-Auth Username (optional)
-| `password`         | HTTP-Basic-Auth Password (optional)
-| `includeAllStates` | include in-progress/stopped state (optional)
+| Setting                       | Description
+|-------------------------------|------------------------------------
+| `url`                         | URL of the Bamboo host
+| `planKey`                     | Plan-Key
+| `username`                    | HTTP-Basic-Auth Username (optional)
+| `password`                    | HTTP-Basic-Auth Password (optional)
+| `includeAllStates`            | include in-progress/stopped state (optional)
+| `latestBuildPerBuildPlanOnly` | request only latest build per build plan. The behavior is similar to `monitor.latestBuildOnly` but this setting limits number of results returned from Bamboo server instead of retrieving all builds and limiting from the application (optional)
 
 #### Bitbucket Pipelines
 

--- a/app/services/Bamboo.js
+++ b/app/services/Bamboo.js
@@ -26,6 +26,10 @@ module.exports = function () {
           params.includeAllStates = "1";
       }
 
+      if (self.configuration.latestBuildPerBuildPlanOnly === true) {
+        params["max-results"] = "1";
+      }
+
       return params;
     },
     requestBuilds = function (callback) {


### PR DESCRIPTION
Hi,

Please help to review my PR
As per your suggestion, I add a new setting `latestBuildPerBuildPlanOnly` to Bamboo service to restrict number of result returned from Bamboo server

Thanks