### PR TITLE
Issue130-Gitlab plugin doesn't add new builds once running

### DIFF
--- a/app/services/GitLab.js
+++ b/app/services/GitLab.js
@@ -68,13 +68,10 @@ module.exports = function () {
             ], callback);
         },
         getBuilds = function(callback) {
-            if(self.projects.length === 0) {
-                loadProjects(function () {
-                    _getBuilds(callback);
-                });
-            } else {
+            self.projects = [];
+            loadProjects(function () {
                 _getBuilds(callback);
-            }
+            });
         },
         _getBuilds = function(callback) {
             async.map(self.projects, getProjectPipelines, function(err, builds) {


### PR DESCRIPTION
Clears the internal project collection in gitlab plugin forces it to query for new projects at the refresh interval