### PR TITLE
Prevent duplicate TFS builds

### DIFF
--- a/app/services/Tfs.js
+++ b/app/services/Tfs.js
@@ -290,7 +290,7 @@ function VSTSRestBuilds() {
 
       let result = {
         definition: build.definition.name,
-        finishedAt: build.finishTime ? new Date(build.finishTime) : new Date(),
+        finishedAt: build.finishTime ? new Date(build.finishTime) : '',
         hasErrors: build.result === resultFilter.failed,
         hasWarnings: build.result === resultFilter.partiallySucceeded,
         id: build.id,


### PR DESCRIPTION
If you have multiple config entries that return overlapping builds, then you can end up with duplicate tiles shown due to some fields being different between the first API call and the next.

Specifically for TFS, the finishedAt time is returned as the current time of the call if the build is still running. This means that when the ETag is generated it makes both builds as unique, when it shouldn't, due to the finishedAt time being different.

I did it this way because I was thinking about making it generic... but while i'm writing this, I think it probably actually makes more sense to just change the `finishedAt: build.finishTime ? new Date(build.finishTime) : new Date(),` to `finishedAt: build.finishTime ? new Date(build.finishTime) : '',` in the TFS.js service.

Thoughts ?