### PR TITLE
[BUGFIX] Adds COPY to Dockerfilefor config.json

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,1 +1,2 @@
 FROM marcells/node-build-monitor
+COPY config.json app/config.json


### PR DESCRIPTION
The problem is that when one don't COPY the config.json over into the Docker-container, it will always start with the default config.json. 

With this fix, the 
`docker-composer up --build` also works with http://localhost:3000 and the rest of the description in the documentation. 