### PR TITLE
Add errorsFirst option for sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The build monitor configuration can be placed in one of the following locations:
     "numberOfBuilds": 12,
     "latestBuildOnly": false,
     "sortOrder": "date",
+    "errorsFirst": false,
     "expandEnvironmentVariables": false,
     "debug": true
   },
@@ -86,6 +87,7 @@ In the `monitor` section you can set up some general settings:
 | `numberOfBuilds`             | The number of builds, which will be read and displayed in the web frontend (ignored if `latestBuildOnly` is enabled)
 | `latestBuildOnly`            | Will only retrieve single latest build from each service configuration. This setting can be overwritten in each service configuration.
 | `sortOrder`                  | The sort order for buils, options : `project`, `date`
+| `errorsFirst`                | Errors should be before success elements, apply sortOrder after that
 | `expandEnvironmentVariables` | Tries to expand root service configuration properties from environment variables (e.g.: "${MY_PASSWORD}" will look for an environment variable `MY_PASSWORD` and will use that)
 | `debug`                      | Enable or disable some debug output on the console
 

--- a/app/monitor.js
+++ b/app/monitor.js
@@ -16,6 +16,18 @@ var async = require('async'),
         }
     },
     sortBuilds = function (newBuilds, sortOrder, errorFirst) {
+        if(sortOrder == "project") {
+            newBuilds.sort(function (a, b) {
+                if(a.project > b.project) return 1;
+                if(a.project < b.project) return -1;
+
+                return 0;
+            });
+        }
+        else {
+            sortBuildsByDate(newBuilds);
+        }
+        
         if (errorFirst)
         {
             var errorChunk = [];
@@ -28,22 +40,7 @@ var async = require('async'),
                     normalChunk.push(newBuilds[i]);
             }
 
-            sortBuilds(errorChunk, sortOrder);
-            sortBuilds(normalChunk, sortOrder);
-
-            return errorChunk.concat(normalChunk);
-        }
-        
-        if(sortOrder == "project") {
-            newBuilds.sort(function (a, b) {
-                if(a.project > b.project) return 1;
-                if(a.project < b.project) return -1;
-
-                return 0;
-            });
-        }
-        else {
-            sortBuildsByDate(newBuilds);
+            newBuilds = errorChunk.concat(normalChunk);
         }
 
         return newBuilds;


### PR DESCRIPTION
We need the date ordering, but the failed builds / test runs should have prio in the ordering over the succeeded once. We need this so that we can react and handle build/test errors as fast as possible.