### PR TITLE
Enable support for tfs api version 4.1

### DIFF
--- a/app/services/Tfs.js
+++ b/app/services/Tfs.js
@@ -76,6 +76,7 @@ function VSTSRestBuilds() {
    */
   const allowedAPIVersions = Object.freeze({
     '2.0':      '2.0',
+    '4.1':      '4.1',
     undefined:  '2.0'
   });
 


### PR DESCRIPTION
Change allowed api versions from 2.0 only to 2.0, 4.1.

Enables use of "maxBuildsPerDefinition" in the queryParam. Other new params also available.

Tested against TFS 2018 on-prem.