### PR TITLE
Add feature to group builds having the same release id

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,18 +229,20 @@ Supports Azure Piplines, the [Azure DevOps](https://azure.microsoft.com/services
     "instance": "instance",
     "username": "username",
     "pat": "personalaccesstoken",
-    "queryparams" : "&$top=10"
+    "queryparams" : "&$top=10",
+    "groupbyrelease": false
   }
 }
 ```
 
-| Setting         | Description
-|-----------------|----------------------------------------------------------------------------------------------------------------------------------------
-| `project`       | Team project ID or name
-| `instance`      | Azure DevOps account without `https://` (dev.azure.com/youraccount/yourcollection) or TFS server (tfs-server:8080/tfs/yourcollection) including collection.
-| `username`      | Username used to login
-| `pat`           | Personal Access Token with access to releases
-| `queryparams`   | Any query params that REST API accepts, more info: https://docs.microsoft.com/en-us/rest/api/vsts/release/deployments/list?view=vsts-rest-4.1#URI_Parameters
+| Setting          | Description
+|------------------|----------------------------------------------------------------------------------------------------------------------------------------
+| `project`        | Team project ID or name
+| `instance`       | Azure DevOps account without `https://` (dev.azure.com/youraccount/yourcollection) or TFS server (tfs-server:8080/tfs/yourcollection) including collection.
+| `username`       | Username used to login
+| `pat`            | Personal Access Token with access to releases
+| `queryparams`    | Any query params that REST API accepts, more info: https://docs.microsoft.com/en-us/rest/api/vsts/release/deployments/list?view=vsts-rest-4.1#URI_Parameters
+| `groupbyrelease` | Group builds by same release id. Defaults to `false`.
 
 _Note_: [Create a peronal access token](https://docs.microsoft.com/en-us/vsts/accounts/use-personal-access-tokens-to-authenticate) with access to read builds.
 - The url formed is of the following format: https://{instance}/{project}/_apis/release/deployments?api-version=4.1-preview[queryparams]


### PR DESCRIPTION
This will add the feature to group builds having the same release id.

Given a release is deployed on multiple environments where one deployment (for the same release) fails:

![tfs-multi-deployment](https://user-images.githubusercontent.com/18613935/57136489-512a3080-6dad-11e9-97ff-8d44e97ddb98.jpg)

It is currently handled on per build basis (`release.id`) instead of grouped builds by release (`release.release.id`) basis:

![tfs-multi-deployment-data](https://user-images.githubusercontent.com/18613935/57136520-6901b480-6dad-11e9-8d94-140afcc20137.jpg)