### PR TITLE
Optionally report TeamCity builds which have failed to start as build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ Supports the [TeamCity](https://www.jetbrains.com/teamcity/) build service.
     "authentication": "ntlm",
     "username": "teamcity_username",
     "password": "teamcity_password",
-    "useGuest": true
+    "useGuest": true,
+    "reportFailedToStart": true
   }
 }
 ```
@@ -179,6 +180,7 @@ Supports the [TeamCity](https://www.jetbrains.com/teamcity/) build service.
 | `username`              | Your TeamCity user name (if required)
 | `password`              | Your TeamCity password (if required)
 | `useGuest`              | Uses the guest user (if required)
+| `reportFailedToStart`   | Causes "Failed to Start" builds to be reported as build failures.
 
 #### Azure DevOps and Team Foundation Server Builds
 

--- a/app/services/TeamCity.js
+++ b/app/services/TeamCity.js
@@ -14,6 +14,9 @@ module.exports = function () {
                 '/app/rest/buildTypes/id:' + self.configuration.buildConfigurationId +
                 '/builds';
             var locators = [];
+            if(self.configuration.reportFailedToStart) {
+                locators.push('failedToStart:any');
+            }
             if(self.configuration.branch) {
                 locators.push('branch:' + self.configuration.branch);
             }
@@ -113,6 +116,7 @@ module.exports = function () {
         getStatus = function (build) {
             if (build.running) return "Blue";
             if (build.canceledInfo) return "Gray";
+            if (build.failedToStart) return "Red";
 
             if (build.status === "SUCCESS") return "Green";
             if (build.status === "FAILURE") return "Red";
@@ -124,6 +128,7 @@ module.exports = function () {
         getStatusText = function (build) {
             if (build.running) return "Running";
             if (build.canceledInfo) return "Canceled";
+            if (build.failedToStart) return "Failed to Start";
 
             if (build.status === "SUCCESS") return "Success";
             if (build.status === "FAILURE") return "Failure";


### PR DESCRIPTION
Hi - 
  I made a simple change to report TeamCity builds which have failed to start as build failures themselves.  We usually encounter this when a dependency fails for some reason -- if that dependency is not itself being monitored (because there are a lot of them, for example), then the build monitor still looks 'green' without this flag.  We'd prefer an indication that the pipeline has failed somewhere, without needing to track each step individually.
  I introduced an option 'reportFailedToStart' to optionally enable this behavior.  

  As far as testing, I ran it through grunt, as well as manual testing through our TeamCity instance.  

  Let me know what you think, and thanks for the project!