### PR TITLE
Add a Drone CI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ __Here's a demo:__ [http://builds.mspi.es](http://builds.mspi.es) <sub><sup>([ot
 - [CCTray](https://sourceforge.net/projects/ccnet/) <sub><sup>([Configuration](#cctray))</sup></sub>
 - [Shippable](https://shippable.com/) <sub><sup>([Configuration](#shippable))</sup></sub>
 - [PRTG](https://www.paessler.com/prtg) <sub><sup>([Configuration](#prtg))</sup></sub>
+- [Drone CI](https://www.drone.io) <sub><sup>([Configuration](#drone-ci))</sup></sub>
 
 Feel free to make a [Fork](https://github.com/marcells/node-build-monitor/fork) of this repository and add another service.
 
@@ -531,6 +532,30 @@ Supports the [PRTG](https://www.paessler.com/prtg) monitoring service.
 | `sensorId`   | Sensor Identifier
 | `username`   | Name of the user
 | `passhash`   | Passhash of the user (Visible under `Configuration` - `My Account`)
+
+
+#### Drone CI
+
+Supports the [Drone CI](https://drone.io) build service (version 1.0 minimum)
+
+```json
+{
+  "name": "Drone",
+  "configuration": {
+    "debug": false,
+    "url": "drone.company.io",
+    "token": "s0meDr0neMachineToken",
+    "slug": "marcells/node-build-monitor"
+  }
+}
+```
+
+| Setting          | Description
+|------------------|--------------------------------------------------------------------------------------------
+| `slug`           | The name of the build (usually your GitHub user name and the project name)
+| `url`            | The Drone CI server (cloud.drone.io, ci.company.io...)..
+| `token`          | The Drone access token, to access the builds. We recommand generating a machine token using the Drone CLI command `drone user add build-monitor --machine`.
+| `branch`  | Set this value to filter the builds from a specific branch. (ie. `master`)
 
 ### Run the standalone version (easiest way)
 

--- a/app/services/Drone.js
+++ b/app/services/Drone.js
@@ -1,0 +1,140 @@
+var request = require("request"),
+  async = require("async");
+
+module.exports = function() {
+  var self = this,
+    requestBuilds = function(callback) {
+      const url = `${self.api_base}/repos/${self.configuration.slug}/builds`;
+      if (self.configuration.debug) {
+        console.info(`Requesting GET ${url}`);
+      }
+
+      request(
+        {
+          method: "GET",
+          url: url,
+          headers: {
+            Authorization: self.configuration.token
+          },
+          json: true
+        },
+        function(error, response, body) {
+          if (!body || body.message === "Unauthorized") {
+            error = `Invalid response ${JSON.stringify(response)}`;
+          }
+          callback(error, body);
+        }
+      );
+    },
+    filterBuilds = function(build) {
+      if (self.configuration.branch) {
+        return build.target === self.configuration.branch;
+      }
+      return true;
+    },
+    queryBuilds = function(callback) {
+      requestBuilds(function(error, body) {
+        if (error) {
+          callback(error);
+          return;
+        }
+
+        callback(
+          error,
+          body.filter(filterBuilds).map(build => simplifyBuild(build))
+        );
+      });
+    },
+    parseDate = function(unix_timestamp) {
+      return new Date(unix_timestamp * 1000);
+    },
+    getStatus = function(status) {
+      // Statuses : https://github.com/drone/drone/blob/5b6a3d8ff4c37283cf37df20d871cc8dfe439565/core/status.go
+      switch (status) {
+        case "pending":
+        case "running":
+        case "waiting_on_dependencies":
+          return "Blue";
+
+        case "skipped":
+        case "blocked":
+        case "killed":
+        default:
+          return "Gray";
+
+        case "declined":
+        case "failure":
+        case "error":
+          return "Red";
+
+        case "success":
+          return "Green";
+      }
+    },
+    simplifyBuild = function(res) {
+      return {
+        id: `drone|${self.configuration.slug}|${res.id}`,
+        project: self.configuration.slug,
+        number: res.number,
+        isRunning: res.finished === 0,
+        startedAt: parseDate(res.started),
+        finishedAt: parseDate(res.finished),
+        requestedFor: res.author_name || res.author_login || res.author_email,
+        status: getStatus(res.status),
+        statusText: res.status,
+        reason: res.event,
+        hasErrors: res.status === "error",
+        hasWarnings: res.status === "blocked",
+        url: `https://${self.configuration.url}/${self.configuration.slug}/${
+          res.number
+        }`
+      };
+    };
+
+  self.configure = function(config) {
+    self.configuration = config;
+
+    if (!self.configuration.slug) {
+      console.error(`[Drone] Please configure the [slug] parameter`);
+      return;
+    }
+
+    if (!self.configuration.url) {
+      console.error(
+        `[Drone ${
+          self.configuration.slug
+        }] Please configure the [url] parameter`
+      );
+      return;
+    }
+
+    if (!self.configuration.token) {
+      console.error(
+        `[Drone ${
+          self.configuration.slug
+        }] Please configure the [token] parameter`
+      );
+      return;
+    }
+
+    self.configuration.url = self.configuration.url;
+    self.configuration.token = self.configuration.token || "";
+
+    if (typeof self.configuration.caPath !== "undefined") {
+      request = request.defaults({
+        agentOptions: {
+          ca: require("fs")
+            .readFileSync(self.configuration.caPath)
+            .toString()
+            .split("\n\n")
+        }
+      });
+    }
+
+    self.api_base = `https://${self.configuration.url}/api`;
+  };
+
+  self.check = function(callback) {
+    queryBuilds(callback);
+  };
+};

--- a/app/services/Drone.js
+++ b/app/services/Drone.js
@@ -59,7 +59,6 @@ module.exports = function() {
         case "skipped":
         case "blocked":
         case "killed":
-        default:
           return "Gray";
 
         case "declined":
@@ -69,6 +68,9 @@ module.exports = function() {
 
         case "success":
           return "Green";
+
+        default:
+          return "Gray";
       }
     },
     simplifyBuild = function(res) {


### PR DESCRIPTION
As DroneCI 1.0 breaks the compatibility with [drone-wall](https://github.com/drone/drone-wall), I think that's the occasion to allow Drone user to migrate to this project.

I created this service to request the Drone > 1.0 API.

One improvement I plan for soon is to listen the /stream endpoint to listen for change instead of doing the requests every X seconds. But this needs some deeper changes, so I prefer to submit two separate Pull Requests.