### PR TITLE
add new theme "twenty" to support displaying 5x4 tiles on a 1920x1080 screen

### DIFF
--- a/app/public/scripts/OptionsViewModel.js
+++ b/app/public/scripts/OptionsViewModel.js
@@ -5,7 +5,7 @@ define(['ko', 'helper', 'settings', 'notification'], function (ko, helper, setti
         self.isMenuVisible = ko.observable(false);
         self.isMenuButtonVisible = ko.observable(false);
         self.theme = ko.observable(helper.getUrlParameter('theme') || settings.theme);
-        self.themes = ko.observableArray(['default', 'stoplight', 'list', 'lingo', 'lowres', 'minimal']);
+        self.themes = ko.observableArray(['default', 'stoplight', 'list', 'lingo', 'lowres', 'minimal', 'twenty']);
         self.browserNotificationSupported = ko.observable(notification.isSupportedAndNotDenied());
         self.browserNotificationEnabled = ko.observable(notification.isSupportedAndNotDenied() && settings.browserNotificationEnabled);
         self.soundNotificationEnabled = ko.observable(settings.soundNotificationEnabled);

--- a/app/public/stylesheets/themes/twenty/style.css
+++ b/app/public/stylesheets/themes/twenty/style.css
@@ -1,0 +1,181 @@
+.twenty-theme .clear {
+  clear: both;
+}
+
+.twenty-theme .nowrap {
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.twenty-theme .box {
+  border: 1px solid black;
+}
+
+.twenty-theme .middle {
+  vertical-align: middle;
+}
+
+.twenty-theme .medium-height {
+    line-height: 40px;
+    height: 40px;
+}
+
+.twenty-theme .reset-height {
+    display: inline-block;
+    line-height: normal;
+}
+
+.twenty-theme .flex-container {
+  padding: 0px;
+  margin: 0 auto 0 auto;
+  height: 100%;
+  width: 100%;
+}
+
+.twenty-theme .flex-item {
+  float: left;
+  width: 25%;
+  height: 20%;
+  color: transparent;
+  position: relative;
+}
+
+.twenty-theme .flex-item-inner {
+  background: transparent;
+  margin: 15px;
+  padding: 10px;
+  box-shadow: 0px 0px 25px 8px rgba(0,0,0,0.8);
+}
+
+.flex-item .overlay {
+  background-color: transparent;
+  position: absolute;
+  margin: 25px;
+  top: 0px;
+  right: 0px;
+}
+
+.flex-item .overlay a {
+  float: left;
+  color: white;
+  font-size: 20pt;
+  background-color: black;
+  display: block;
+  width: 50px;
+  height: 50px;
+  line-height: 50px;
+  text-align: center;
+  vertical-align: middle;
+  opacity: 0.8;
+}
+
+.twenty-theme .flex-item .info-block {
+  float: left;
+  font-size: 15pt;
+}
+
+.twenty-theme .flex-item .project {
+  font-weight: bold;
+}
+
+.twenty-theme .flex-item .project-definition-separator {
+  border-left: 1px solid;
+  padding-left: 10px;
+  margin-left: 10px
+}
+
+.twenty-theme .flex-item .definition {
+}
+
+.twenty-theme .flex-item .number {
+  font-size: 20pt;
+}
+
+.twenty-theme .flex-item .duration-block {
+  float: right;
+  font-size: 10pt;
+}
+
+.twenty-theme .flex-item .duration-icon {
+  font-size: 35px;
+  float: left;
+  margin-top: 3px;
+}
+
+.twenty-theme .flex-item .time {
+  margin-left: 10px;
+}
+
+.twenty-theme .flex-item .status {
+  float: left;
+  font-family: 'open_sans_condensedbold';
+  font-weight: bold;
+  font-size: 25pt;
+}
+
+.twenty-theme .flex-item .reason {
+  margin-left: 10px;
+  font-size: 15pt;
+}
+
+.twenty-theme .flex-item .reason-icon {
+  font-size: 25px;
+}
+
+.twenty-theme .flex-item .reason-block {
+  float: right;
+}
+
+.twenty-theme .flex-item .for {
+  margin-left: 15px;
+  font-size: 20px;
+}
+
+.twenty-theme .requestedFor-block {
+  font-size: 15pt;
+  float: left;
+  vertical-align: middle;
+}
+
+.twenty-theme .flex-item .warnings {
+  font-weight: bold;
+  font-size: 20pt;
+  float: right;
+  vertical-align: middle;
+}
+
+@media (max-height: 600px) {
+  .twenty-theme .prio-vertical-one {
+    display: none;
+  }
+}
+
+@media (max-height: 760px) {
+  .twenty-theme .prio-vertical-two {
+    display: none;
+  }
+}
+
+@media (max-height: 900px) {
+  .twenty-theme .prio-vertical-three {
+    display: none;
+  }
+}
+
+@media (max-width: 870px) {
+  .twenty-theme .prio-horizontal-one {
+    display: none;
+  }
+}
+
+@media (max-width: 1000px) {
+  .twenty-theme .prio-horizontal-two {
+    display: none;
+  }
+}
+
+@media (max-width: 1300px) {
+  .twenty-theme .prio-horizontal-three {
+    display: none;
+  }
+}

--- a/app/public/templates/themes/twenty.html
+++ b/app/public/templates/themes/twenty.html
@@ -1,0 +1,48 @@
+<div class="twenty-theme full-size">
+  <div class="flex-container" data-bind="foreach: builds">
+    <div data-bind='hover: isMenuVisible' class="flex-item">
+      <div data-bind="animateCss: style" class="flex-item-inner nowrap">
+        <span data-bind="text: number" class="number nowrap"></span>
+        <div class="clear"></div>
+        <div class="medium-height nowrap prio-vertical-two">
+          <span class="info-block middle">
+            <span data-bind="text: project" class="project"></span>
+            <span data-bind="text: definition, visible: definition" class="definition project-definition-separator"></span>
+          </span>
+          <span class="reason-block prio-horizontal-two">
+            <span class="reason-icon middle fa fa-cog"></span>
+            <span data-bind="text: reason" class="middle reason"></span>
+          </span>
+        </div>
+        <div class="clear"></div>
+        <div class="clear"></div>
+        <div class="medium-height nowrap prio-vertical-three">
+          <span data-bind="text: statusText" class="middle status"></span>
+        </div>
+        <div class="medium-height nowrap prio-vertical-two">
+          <span class="middle requestedFor-block">
+            <span class="middle fa fa-user"></span>
+            <span data-bind="text: requestedFor" class="middle for"></span>
+          </span>
+          <span class="middle warnings prio-horizontal-one">
+            <span data-bind="visible: hasWarnings" class="middle fa fa-exclamation-triangle"></span>
+            <span data-bind="visible: hasErrors" class="middle fa fa-times-circle"></span>
+          </span>
+          <span class="middle duration-block reset-height prio-horizontal-three">
+            <span class="duration-icon fa fa-clock-o"></span>
+            <span data-bind="text: time" class="middle time"></span>
+            <br />
+            <span data-bind="text: duration" class="middle time"></span>
+          </span>
+        </div>
+        <div class="clear"></div>
+      </div>
+
+      <div data-bind="fade: isMenuAvailable() && isMenuVisible(), fadeInDuration: 200, fadeOutDuration: 10" style="display: none" class="overlay">
+        <a data-bind="visible: url, attr: { href: url }" target="_blank">
+          <i class="fa fa-external-link"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This theme is based on the default theme, but more condensed to be able to see 20 tiles on a 1920x1080 screen in full screen mode.
I also moved the "times" section into the bottom row in order to get more space for displaying the build status when builds are in progress.
![twenty](https://user-images.githubusercontent.com/1249745/66766181-c9913380-eead-11e9-8c6f-ff134d79b343.png)
