### PR TITLE
TfsRelease - Support API version 3.2-preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ Supports Azure Piplines, the [Azure DevOps](https://azure.microsoft.com/services
     "username": "username",
     "pat": "personalaccesstoken",
     "queryparams" : "&$top=10",
-    "groupbyrelease": false
+    "groupbyrelease": false,
+    "apiVersion": "4.1"
   }
 }
 ```
@@ -252,11 +253,12 @@ Supports Azure Piplines, the [Azure DevOps](https://azure.microsoft.com/services
 | `pat`            | Personal Access Token with access to releases
 | `queryparams`    | Any query params that REST API accepts, more info: [VSTS Rest Uri parameters](https://docs.microsoft.com/en-us/rest/api/vsts/release/deployments/list?view=vsts-rest-4.1#URI_Parameters)
 | `groupbyrelease` | Group builds by same release id. Defaults to `false`.
+| `apiVersion`     | The API version to target. Defaults to `4.1-preview`. Allowed values are: `3.2-preview` `4.1-preview`
 
 _Note_: [Create a personal access token](https://docs.microsoft.com/en-us/vsts/accounts/use-personal-access-tokens-to-authenticate) with access to read builds.
 
 - The url formed is of the following format:
-  `https://{instance}/{project}/_apis/release/deployments?api-version=4.1-preview[queryparams]`
+  `https://{instance}/{project}/_apis/release/deployments?api-version={apiVersion}[queryparams]`
 - Please note that all the configuration fields are mandatory. If a field is not required like `queryparams`, please provide empty string in the configuration.
 
 #### Team Foundation Server 2013 and lower (on-premise)

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Supports Azure Piplines, the [Azure DevOps](https://azure.microsoft.com/services
     "pat": "personalaccesstoken",
     "queryparams" : "&$top=10",
     "groupbyrelease": false,
-    "apiVersion": "4.1"
+    "apiVersion": "4.1-preview"
   }
 }
 ```

--- a/app/requests.js
+++ b/app/requests.js
@@ -39,7 +39,7 @@ module.exports = {
                   callback(error);
                 } else {
                   // If the request never reached the server, then chances are the error object is null, so lets return a status code error instead
-                  callback(new Error(httpErrRes));
+                  callback(new Error(httpErrRes), body);
                 }
               }
               else{

--- a/app/services/TfsRelease.js
+++ b/app/services/TfsRelease.js
@@ -53,9 +53,11 @@ function TfsRestRelease() {
    * @private
    */
   const allowedAPIVersions = Object.freeze({
-    '3.2':      '3.2-preview',
-    '4.1':      '4.1-preview',
-    undefined:  '4.1-preview'
+    '3.2':            '3.2-preview',
+    '3.2-preview':    '3.2-preview',
+    '4.1':            '4.1-preview',
+    '4.1-preview':    '4.1-preview',
+    undefined:        '4.1-preview'
   });
 
   /**

--- a/app/services/TfsRelease.js
+++ b/app/services/TfsRelease.js
@@ -17,6 +17,7 @@ function TfsRestRelease() {
   let protocol = null;
   let params = null;
   let groupbyrelease = null;
+  let apiVersion = null;
 
   /**
    * This object is the representation of resultFilter mentioned in the docs
@@ -45,6 +46,16 @@ function TfsRestRelease() {
     partiallySucceeded: '#F8A800',
     succeeded: 'Green',
     undefined: 'Gray'
+  });
+
+  /**
+   * This object defines the compatable api versions that we are allowed to use
+   * @private
+   */
+  const allowedAPIVersions = Object.freeze({
+    '3.2':      '3.2-preview',
+    '4.1':      '4.1-preview',
+    undefined:  '4.1-preview'
   });
 
   /**
@@ -101,6 +112,7 @@ function TfsRestRelease() {
    * @property {string} pat Personal Access Token with access to Release
    *  information
    * @property {boolean} groupbyrelease Group builds by same release id
+   * @property {string} apiVersion The TFS API version to use. This must be at least 3.2-preview or higher
    */
 
   /**
@@ -128,6 +140,7 @@ function TfsRestRelease() {
     params = config.queryparams;
     project = config.project;
     groupbyrelease = config.groupbyrelease || false;
+    apiVersion = allowedAPIVersions[config.apiVersion];
 
     console.log(config);
   };
@@ -142,7 +155,7 @@ function TfsRestRelease() {
         protocol = "https";
     }
     
-    const url = `${protocol}://${instance}/${project}/_apis/release/deployments?api-version=4.1-preview${params}`;
+    const url = `${protocol}://${instance}/${project}/_apis/release/deployments?api-version=${apiVersion}${params}`;
     const options = {
       url,
       headers: {
@@ -151,6 +164,10 @@ function TfsRestRelease() {
     };
     request.makeRequest(options, (err, body) => {
       transformData(err, body, callback);
+      if (err) {
+          console.log(url);
+          console.log(body || null);
+      }
     });
 
     /**
@@ -246,6 +263,12 @@ function TfsRestRelease() {
      * @returns {Release} the object is in the format accepted by the application
      */
     const transformer = (release) => {
+      let startTime = new Date(release.startedOn);
+      // api version 3.2 populates 'null' timestamps with 1/1/1 (for some unhelpful reason)
+      if (startTime.getTime() === new Date('0001-01-01T00:00:00').getTime()) {
+          starTime = new Date(release.queuedOn);
+      }
+      
       let result = {
         finishedAt: release.completedOn ? new Date(release.completedOn) : new Date(),
         hasErrors: release.deploymentStatus === resultFilter.failed,
@@ -256,7 +279,7 @@ function TfsRestRelease() {
         project: release.releaseDefinition.name,
         reason: release.reason,
         requestedFor: release.requestedFor.displayName,
-        startedAt: new Date(release.queuedOn),
+        startedAt: startTime,
         status: colorScheme[resultFilter[release.deploymentStatus ? release.deploymentStatus : resultFilter.inProgress]],
         statusText: release.deploymentStatus ? release.deploymentStatus : resultFilter.inProgress,
         url: release.release.webAccessUri


### PR DESCRIPTION
Relax the API restriction to when releases were first available via the API (2017 Update 2)

(I decided to leave my error handling in there, so its easier in the future to work out why TFS rejected an API call, but I can remove it if required.)

EDIT:
Also fixed the startTime field always being populated with the queuedTime of the Release, when the startTime field should have been used instead)