### PR TITLE
Report failures as errors

### DIFF
--- a/app/services/Drone.js
+++ b/app/services/Drone.js
@@ -90,7 +90,7 @@ module.exports = function() {
         status: getStatus(res.status),
         statusText: res.status,
         reason: res.event,
-        hasErrors: res.status === "error",
+        hasErrors: res.status === "error" || res.status === "failure",
         hasWarnings: res.status === "blocked",
         url: `https://${self.configuration.url}/${self.configuration.slug}/${
           res.number


### PR DESCRIPTION
DroneCI reports failed builds with a status of 'error' or 'failure'

![Screenshot 2020-01-29 at 12 45 22](https://user-images.githubusercontent.com/4256301/73358035-a42a0900-4295-11ea-8680-9d1662c7558e.png)
