### PR TITLE
Fix Build steps displaying incorrectly for TFS 2019

### DIFF
--- a/app/services/Tfs.js
+++ b/app/services/Tfs.js
@@ -412,7 +412,7 @@ function VSTSRestBuilds() {
       
       for (let key in records) {
         let record = records[key];
-        if (record.state === timelineRecordState.inProgress) {
+        if (record.state === timelineRecordState.inProgress && record.type === 'Task') {
           build.statusText += ' - ' + record.name;
         }
       }

--- a/app/services/Tfs.js
+++ b/app/services/Tfs.js
@@ -379,7 +379,7 @@ function VSTSRestBuilds() {
   const getLatestBuildStep = (build, callback) => {
     const timelineURL = build.timeline;
     if (!timelineURL || timelineURL === '') {
-      console.log("no timeline url");
+      console.log('no timeline url');
       callback(null, build);
       return;
     }
@@ -394,13 +394,13 @@ function VSTSRestBuilds() {
     
     request.makeRequest(options, (err, body) => {
       if (err) {
-        console.log("getLatestBuildStep:", err);
+        console.log('getLatestBuildStep:', err);
         callback(null, build);
         return;
       }
       
       if (!(body && body.records)) {
-        console.log("getLatestBuildStep invalid Body", body);
+        console.log('getLatestBuildStep invalid Body', body);
         callback(null, build);
         return;
       }


### PR DESCRIPTION
This fixes a TFS 2019 (and probably 2018) bug, where multiple build Statuses were incorrectly shown, as getLatestBuildStep wasn't correctly filtering TimelineRecords of type Task.

(For some reason Microsoft has made the TimelineRecord.Type field a String ... so I couldn't create an enum style list like the others)

This should still work for 2017, although now that we (finally) upgraded, I don't really have a way to fully test this, outside just assuming Microsoft haven't touched the version 2.0 API call in 2019.