### PR TITLE
Reduce calls to TFS server when showBuildStep is enabled

### DIFF
--- a/app/services/Tfs.js
+++ b/app/services/Tfs.js
@@ -384,6 +384,12 @@ function VSTSRestBuilds() {
       return;
     }
     
+    if (!build.isRunning) {
+        // The build is already finished, no need to get the latest step
+        callback(null, build);
+        return;
+    }
+    
     const apiUrl = timelineURL;
     const options = {
       url : apiUrl,


### PR DESCRIPTION
I probably should have commited this a while ago :(

Specifically in TFS/Azure DevOps 2020, the API limiting 'CircuitBreaker' seems a little more picky on how often things are called.
So, while researching ways to increase this limit - it occurred to me, that we really don't need to get build steps for ones that have already finished running.

This resulted (for me) in significantly less calls to the API - going from 14 per refresh down to at most 4.
(Based on only showing 12 builds or releases on screen at one time)